### PR TITLE
Fix `invalid function` errors when using native compilation

### DIFF
--- a/lsp-proxy-imenu.el
+++ b/lsp-proxy-imenu.el
@@ -15,18 +15,13 @@
 
 (require 'cl-lib)
 (require 'eglot)
+(require 'lsp-proxy-core)
 (require 'lsp-proxy-utils)
 
 (defcustom lsp-proxy-enable-imenu t
   "Enable imenu integration."
   :type 'boolean
   :group 'lsp-proxy)
-
-;;; External functions
-(declare-function lsp-proxy--request "lsp-proxy-core")
-
-;;; External variables
-(defvar lsp-proxy--support-document-symbols)
 
 (cl-defun lsp-proxy-imenu ()
   "LSP-Proxy's `imenu-create-index-function'.

--- a/lsp-proxy-inline-completion.el
+++ b/lsp-proxy-inline-completion.el
@@ -16,12 +16,10 @@
 (require 'cl-lib)
 (require 'eglot)
 (require 'dash)
+(require 'lsp-proxy-core)
 (require 'lsp-proxy-utils)
 
 (defvar lsp-proxy-inline-completion-mode)
-
-;;; External functions
-(declare-function lsp-proxy--async-request "lsp-proxy-core")
 
 ;;; Configuration
 

--- a/lsp-proxy-large-file.el
+++ b/lsp-proxy-large-file.el
@@ -14,6 +14,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'lsp-proxy-core)
 (require 'lsp-proxy-utils)
 
 ;;; Configuration
@@ -32,9 +33,6 @@
   "Chunk size for loading large files."
   :type 'integer
   :group 'lsp-proxy)
-
-;;; External functions
-(declare-function lsp-proxy--notify "lsp-proxy-core")
 
 ;;; Variables
 

--- a/lsp-proxy-signature.el
+++ b/lsp-proxy-signature.el
@@ -14,13 +14,8 @@
 ;;; Code:
 
 (require 'eglot)
+(require 'lsp-proxy-core)
 (require 'lsp-proxy-utils)
-
-;;; External functions
-(declare-function lsp-proxy--async-request "lsp-proxy-core")
-
-;;; External variables
-(defvar lsp-proxy--support-signature-help)
 
 (defun lsp-proxy-signature-eldoc-function (cb)
   "Eldoc function for signature help with callback CB."


### PR DESCRIPTION
When native-compiled, instead of signature help for example, an error is displayed in the echo area: `eldoc: Invalid function: lsp-proxy--async-request`

`lsp-proxy--async-request` is a macro, and cannot be autoloaded by declare-function. The simplest fix is just loading `lsp-proxy-core`. At runtime it will be loaded anyway so there is no benefit in not depending on it.

A similar issue is present for imenu and large file handling.

---

Thanks for this package!