### PR TITLE
feat: add SSH/RPC-based remote development support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,6 +549,7 @@ dependencies = [
  "itertools 0.13.0",
  "jod-thread",
  "lazy_static",
+ "libc",
  "log",
  "lsp-types",
  "num_cpus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,6 +565,7 @@ dependencies = [
  "stringslice",
  "tempfile",
  "thiserror 1.0.69",
+ "time",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +49,12 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -132,12 +149,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -158,6 +218,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,11 +252,29 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -191,9 +292,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -292,6 +408,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,7 +441,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -344,10 +477,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b23360e99b8717f20aaa4598f5a6541efbe30630039fbc7706cf954a87947ae"
 
 [[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -387,13 +538,15 @@ name = "lsp-proxy"
 version = "0.7.2"
 dependencies = [
  "anyhow",
+ "async-trait",
  "crossbeam-channel",
  "dunce",
  "etcetera",
+ "futures",
  "futures-executor",
  "futures-util",
  "globset",
- "itertools",
+ "itertools 0.13.0",
  "jod-thread",
  "lazy_static",
  "log",
@@ -401,17 +554,24 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parking_lot",
+ "prost",
+ "prost-build",
+ "protoc-bin-vendored",
+ "regex",
  "serde",
  "serde_json",
  "smallvec",
  "stringslice",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "uuid",
  "which",
 ]
 
@@ -453,6 +613,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nu-ansi-term"
@@ -524,6 +690,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +727,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +744,123 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools 0.12.1",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "quote"
@@ -569,12 +872,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -608,10 +929,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -742,6 +1075,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +1213,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]
@@ -1006,6 +1366,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1391,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,6 +1412,103 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "which"
@@ -1143,6 +1617,100 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ async-trait = "0.1"
 [profile.release]
 lto = "fat"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [build-dependencies]
 prost-build = "0.12"
 protoc-bin-vendored = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ lazy_static = "1.4.0"
 smallvec = "1.13.1"
 itertools = "0.13.0"
 once_cell = "1.20.2"
+time = { version = "0.3", features = ["formatting", "macros", "local-offset"] }
 etcetera = "0.8.0"
 futures = "0.3"
 tokio-util = { version = "0.7", features = ["compat"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,17 @@ smallvec = "1.13.1"
 itertools = "0.13.0"
 once_cell = "1.20.2"
 etcetera = "0.8.0"
+futures = "0.3"
+tokio-util = { version = "0.7", features = ["compat"] }
+regex = "1.0"
+uuid = { version = "1.0", features = ["v4"] }
+tempfile = "3.0"
+prost = "0.12"
+async-trait = "0.1"
 
 [profile.release]
 lto = "fat"
+
+[build-dependencies]
+prost-build = "0.12"
+protoc-bin-vendored = "3"

--- a/README.md
+++ b/README.md
@@ -773,14 +773,14 @@ For specialized setups, you can extend the language mapping:
 
 ## Remote Development
 
-LSP-Proxy supports transparent remote development over SSH via Emacs TRAMP. When you open a TRAMP file, the local lsp-proxy process automatically deploys itself to the remote host, starts a remote server process, and routes all LSP traffic through the SSH tunnel — no manual setup required.
+LSP-Proxy supports transparent remote development over SSH via Emacs TRAMP. When you open a TRAMP file, the local lsp-proxy process checks whether a compatible binary exists on the remote host, starts a remote server process, and routes all LSP traffic through the SSH tunnel. Binary deployment is controlled by `lsp-proxy-remote-deploy-mode` — either manually on demand or automatically in the background.
 
 ### How It Works
 
 1. You open a file with a TRAMP path (e.g., `/ssh:myserver:/home/user/project/main.rs`)
 2. lsp-proxy detects the `/ssh:` prefix and establishes an SSH ControlMaster connection
-3. It checks whether a compatible binary exists on the remote at `lsp-proxy-remote-binary-path`
-4. If the binary is missing or the version doesn't match, it `scp`-uploads the currently-running local binary
+3. It checks whether `emacs-lsp-proxy` is available in the remote PATH; if the version matches, it is used directly without uploading any file
+4. If the global command is absent or has a version mismatch, lsp-proxy checks the fixed deploy path (`lsp-proxy-remote-binary-path`). If neither location has a matching binary, deployment is triggered according to `lsp-proxy-remote-deploy-mode` (see [Binary Deployment](#binary-deployment))
 5. The remote binary is started with `--remote-server`; LSP traffic is forwarded through the tunnel
 6. From Emacs's perspective, everything works the same as a local buffer
 
@@ -821,31 +821,110 @@ lsp-proxy handles binary deployment and tunnel setup on first access. Subsequent
 ;; Change where the binary is deployed on the remote host
 ;; Default: "~/.cache/emacs/lsp-proxy/emacs-lsp-proxy"
 (setq lsp-proxy-remote-binary-path "/opt/tools/emacs-lsp-proxy")
+
+;; Deploy mode: 'manual (default) or 'auto
+(setq lsp-proxy-remote-deploy-mode 'manual)
 ```
+
+### Binary Deployment
+
+When the binary check fails (missing or version mismatch on both the global command and the deploy path), lsp-proxy behaves according to `lsp-proxy-remote-deploy-mode`.
+
+#### `manual` (default)
+
+lsp-proxy prints a hint in the minibuffer and waits for you to act:
+
+```
+[lsp-proxy] Remote binary unavailable on myserver (…). Run M-x lsp-proxy-remote-deploy to deploy v0.7.2 to ~/.cache/…
+```
+
+Run `M-x lsp-proxy-remote-deploy` to open the `*lsp-proxy-deploy*` buffer. It shows the check result for both locations, then asks for confirmation before uploading:
+
+```
+Deploy log — myserver  [manual]  (started 2026-05-19 10:30:00)
+------------------------------------------------------------
+
+[10:30:00] Checking remote binary...
+
+[10:30:01] Local version : 0.7.2
+[10:30:01] Deploy path   : ~/.cache/emacs/lsp-proxy/emacs-lsp-proxy
+
+[10:30:01] Global command (emacs-lsp-proxy): ✗ not found in PATH
+[10:30:01] Deploy path   (~/.cache/…):       ✗ not found
+
+[10:30:01] Binary not available or outdated. Deploy required.
+```
+
+Confirm the `[lsp-proxy] Deploy v0.7.2 to myserver?` prompt and the upload begins, with each step appended to the same buffer. Re-open the remote file once the deploy succeeds.
+
+#### `auto`
+
+lsp-proxy starts the upload immediately as soon as the check fails, streaming each step to the `*lsp-proxy-deploy*` buffer so you can follow along without doing anything:
+
+```
+Deploy log — myserver  [auto]  (started 2026-05-19 10:30:00)
+------------------------------------------------------------
+
+[10:30:00] Binary unavailable (…). Starting automatic deploy of v0.7.2...
+[10:30:00] Target path: ~/.cache/emacs/lsp-proxy/emacs-lsp-proxy
+[10:30:00] Starting upload...
+[10:30:01] Checking global emacs-lsp-proxy on remote (need v0.7.2)...
+[10:30:01] Global emacs-lsp-proxy not found in remote PATH.
+[10:30:01] Checking ~/.cache/emacs/lsp-proxy/emacs-lsp-proxy...
+[10:30:01] Uploading /usr/local/bin/emacs-lsp-proxy (8388608 bytes)...
+[10:30:04] Upload complete, verifying...
+[10:30:04] ✓ Deploy succeeded. Binary: ~/.cache/emacs/lsp-proxy/emacs-lsp-proxy
+```
+
+Re-open the remote file once the deploy completes.
+
+#### `M-x lsp-proxy-remote-deploy`
+
+This command is always available regardless of the deploy mode. It runs the full check-and-deploy flow interactively, defaulting to the host that most recently requested a deploy. Use it to re-deploy after a version upgrade or to recover from a failed auto-deploy.
 
 ### Diagnostics
 
-Check the current remote connection status from `M-x lsp-proxy-doctor`. The **Remote Connection Status** section shows:
+**Connection status** — run `M-x lsp-proxy-doctor` and check the **Remote Connection Status** section:
 
 | Field | Meaning |
 |---|---|
-| `Binary Path` | Path used on the remote host |
+| `Binary Path` | Command or path actually used (`emacs-lsp-proxy` if the global command was selected, otherwise the deploy path) |
 | `Deploy Status` | `deployed`, `missing`, `version_mismatch`, or `unknown` |
 | `Local Version` | Version of your local lsp-proxy binary |
 | `Remote Version` | Version reported by the remote binary |
 
-For deeper debugging, increase the log level before opening the remote file:
+**Check the remote binary manually** — verify which binary is in use and its version:
+
+```bash
+# Global command (preferred when available)
+ssh myserver 'emacs-lsp-proxy --version'
+
+# Deployed binary at the default path
+ssh myserver '~/.cache/emacs/lsp-proxy/emacs-lsp-proxy --version'
+```
+
+**View the remote log** — each server start creates a new timestamped log file next to the binary (`~/.cache/emacs/lsp-proxy/remote-server-YYYYMMDD-HHMMSS.log`). First set the log level so output is written, then open the remote file to trigger a fresh start:
 
 ```elisp
 (setq lsp-proxy-log-level 2)
 ```
 
-Then `M-x lsp-proxy-open-log-file` to inspect SSH connection and deploy steps.
+```bash
+# Print the latest log
+ssh myserver 'ls -t ~/.cache/emacs/lsp-proxy/remote-server-*.log | head -1 | xargs cat'
+
+# Follow in real time while reproducing the issue
+ssh myserver 'ls -t ~/.cache/emacs/lsp-proxy/remote-server-*.log | head -1 | xargs tail -f'
+
+# Clean up old logs, keeping the 5 most recent
+ssh myserver 'ls -t ~/.cache/emacs/lsp-proxy/remote-server-*.log | tail -n +6 | xargs rm -f'
+```
 
 ### Troubleshooting
 
 | Issue | Solution |
 |---|---|
+| Remote binary missing, no prompt shown | Check `lsp-proxy-remote-deploy-mode`; in `manual` mode the hint appears in the minibuffer — run `M-x lsp-proxy-remote-deploy` |
 | Deploy fails with permission error | Ensure the remote directory is writable; set `lsp-proxy-remote-binary-path` to a writable path |
 | Binary architecture mismatch | Cross-platform deploy is not supported; the local binary must match the remote OS/arch |
 | SSH connection times out | Configure `ServerAliveInterval` / `ServerAliveCountMax` in `~/.ssh/config` |

--- a/README.md
+++ b/README.md
@@ -834,13 +834,13 @@ When the binary check fails (missing or version mismatch on both the global comm
 
 lsp-proxy prints a hint in the minibuffer and waits for you to act:
 
-```
+```text
 [lsp-proxy] Remote binary unavailable on myserver (…). Run M-x lsp-proxy-remote-deploy to deploy v0.7.2 to ~/.cache/…
 ```
 
 Run `M-x lsp-proxy-remote-deploy` to open the `*lsp-proxy-deploy*` buffer. It shows the check result for both locations, then asks for confirmation before uploading:
 
-```
+```text
 Deploy log — myserver  [manual]  (started 2026-05-19 10:30:00)
 ------------------------------------------------------------
 
@@ -861,7 +861,7 @@ Confirm the `[lsp-proxy] Deploy v0.7.2 to myserver?` prompt and the upload begin
 
 lsp-proxy starts the upload immediately as soon as the check fails, streaming each step to the `*lsp-proxy-deploy*` buffer so you can follow along without doing anything:
 
-```
+```text
 Deploy log — myserver  [auto]  (started 2026-05-19 10:30:00)
 ------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -771,6 +771,87 @@ For specialized setups, you can extend the language mapping:
 | Wrong language server started | Check `lsp-proxy-org-babel-language-map` for correct mapping |
 | Edit buffer not getting LSP | Verify `lsp-proxy-org-edit-special-enable-lsp` is `t` |
 
+## Remote Development
+
+LSP-Proxy supports transparent remote development over SSH via Emacs TRAMP. When you open a TRAMP file, the local lsp-proxy process automatically deploys itself to the remote host, starts a remote server process, and routes all LSP traffic through the SSH tunnel — no manual setup required.
+
+### How It Works
+
+1. You open a file with a TRAMP path (e.g., `/ssh:myserver:/home/user/project/main.rs`)
+2. lsp-proxy detects the `/ssh:` prefix and establishes an SSH ControlMaster connection
+3. It checks whether a compatible binary exists on the remote at `lsp-proxy-remote-binary-path`
+4. If the binary is missing or the version doesn't match, it `scp`-uploads the currently-running local binary
+5. The remote binary is started with `--remote-server`; LSP traffic is forwarded through the tunnel
+6. From Emacs's perspective, everything works the same as a local buffer
+
+### Supported TRAMP Methods
+
+| TRAMP path form | Description |
+|---|---|
+| `/ssh:host:/path` | SSH config alias (user resolved via `~/.ssh/config`) |
+| `/ssh:user@host:/path` | Explicit username |
+| `/ssh:user@host#port:/path` | Custom SSH port |
+| `/rpc:user@host:/path` | RPC tunnel (alternative to ssh method) |
+
+### Prerequisites
+
+- SSH access to the remote host (password-less key auth recommended)
+- The local `emacs-lsp-proxy` binary must be compatible with the remote host's architecture (Linux x86-64 or ARM64)
+- The remote user needs write permission to the deploy directory (default: `~/.cache/emacs/lsp-proxy/`)
+
+### Basic Usage
+
+No special configuration is required. Enable `lsp-proxy-mode` normally, then open any TRAMP file:
+
+```elisp
+;; In your init file — same hook as local files
+(add-hook 'typescript-ts-mode-hook #'lsp-proxy-mode)
+```
+
+```elisp
+;; Open a remote file — lsp-proxy-mode activates automatically
+(find-file "/ssh:myserver:/home/user/project/main.rs")
+```
+
+lsp-proxy handles binary deployment and tunnel setup on first access. Subsequent files on the same host reuse the existing SSH connection.
+
+### Customization
+
+```elisp
+;; Change where the binary is deployed on the remote host
+;; Default: "~/.cache/emacs/lsp-proxy/emacs-lsp-proxy"
+(setq lsp-proxy-remote-binary-path "/opt/tools/emacs-lsp-proxy")
+```
+
+### Diagnostics
+
+Check the current remote connection status from `M-x lsp-proxy-doctor`. The **Remote Connection Status** section shows:
+
+| Field | Meaning |
+|---|---|
+| `Binary Path` | Path used on the remote host |
+| `Deploy Status` | `deployed`, `missing`, `version_mismatch`, or `unknown` |
+| `Local Version` | Version of your local lsp-proxy binary |
+| `Remote Version` | Version reported by the remote binary |
+
+For deeper debugging, increase the log level before opening the remote file:
+
+```elisp
+(setq lsp-proxy-log-level 2)
+```
+
+Then `M-x lsp-proxy-open-log-file` to inspect SSH connection and deploy steps.
+
+### Troubleshooting
+
+| Issue | Solution |
+|---|---|
+| Deploy fails with permission error | Ensure the remote directory is writable; set `lsp-proxy-remote-binary-path` to a writable path |
+| Binary architecture mismatch | Cross-platform deploy is not supported; the local binary must match the remote OS/arch |
+| SSH connection times out | Configure `ServerAliveInterval` / `ServerAliveCountMax` in `~/.ssh/config` |
+| Remote LSP not starting | Set `lsp-proxy-log-level` to `2`, reopen the file, check the log for SSH/deploy errors |
+| Features stop working after reconnect | Run `M-x lsp-proxy-restart` to re-establish the remote session |
+
 ## Acknowledgements
 Thanks to [Helix](https://github.com/helix-editor/helix), the architecture of Lsp-Proxy Server is entirely based on Helix's implementation. Language configuration and communication with different language servers are all dependent on Helix. As a Rust beginner, I've gained a lot from this approach during the implementation.
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,16 @@
+fn main() {
+    println!("cargo:rerun-if-changed=proto/rpc.proto");
+
+    // Prefer a user-supplied protoc if $PROTOC is set; otherwise fall back to
+    // the bundled binary so the crate builds without a system install.
+    if std::env::var_os("PROTOC").is_none() {
+        let protoc_path = protoc_bin_vendored::protoc_bin_path()
+            .expect("protoc-bin-vendored binary not found");
+        std::env::set_var("PROTOC", protoc_path);
+    }
+
+    let mut config = prost_build::Config::new();
+    config
+        .compile_protos(&["proto/rpc.proto"], &["proto"])
+        .expect("failed to compile rpc.proto");
+}

--- a/languages.toml
+++ b/languages.toml
@@ -420,7 +420,7 @@ file-types = [
   "avsc",
   { glob = ".prettierrc" },
 ]
-language-servers = ["vscode-json-language-server"]
+language-servers = [{name = "vscode-json-language-server", support-workspace = true}]
 
 [[language]]
 name = "java"

--- a/languages.toml
+++ b/languages.toml
@@ -344,7 +344,7 @@ file-types = [
   { glob = "Cargo.lock" },
   { glob = "uv.lock" },
 ]
-language-servers = ["taplo"]
+language-servers = [{ name = "taplo", support-workspace = true }]
 
 [[language]]
 name = "bash"

--- a/lsp-proxy-completion.el
+++ b/lsp-proxy-completion.el
@@ -118,7 +118,7 @@ instead of sending LSP requests."
                    (resp (lsp-proxy--request
                           'textDocument/completion
                           (lsp-proxy--build-params
-                           (eglot--TextDocumentPositionParams)
+                           (lsp-proxy--TextDocumentPositionParams)
                            `(:context
                              (:line ,(buffer-substring-no-properties (line-beginning-position) (line-end-position))
                               :prefix ,prefix

--- a/lsp-proxy-copilot.el
+++ b/lsp-proxy-copilot.el
@@ -27,7 +27,7 @@ Returns a promise that resolves with the response."
   (unless buffer-file-name
     (user-error "Buffer must be visiting a file to communicate with Copilot"))
 
-  (let* ((uri-plist (eglot--TextDocumentIdentifier))
+  (let* ((uri-plist (lsp-proxy--TextDocumentIdentifier))
          (uri (plist-get uri-plist :uri)))
     (lsp-proxy--request
      'emacs/forwardRequest

--- a/lsp-proxy-core.el
+++ b/lsp-proxy-core.el
@@ -525,7 +525,7 @@ Records BEG, END and PRE-CHANGE-LENGTH locally."
                            (string= lsp-proxy--text-document-sync-kind "full"))))
       (lsp-proxy--notify 'textDocument/didChange
                          (list :textDocument
-                               (eglot--VersionedTextDocumentIdentifier)
+                               (lsp-proxy--VersionedTextDocumentIdentifier)
                                :contentChanges
                                (if full-sync-p
                                    (vector (list :text (eglot--widening

--- a/lsp-proxy-core.el
+++ b/lsp-proxy-core.el
@@ -392,7 +392,7 @@ Only sends requests if servers are available."
   (when (eql method 'emacs/remoteDeployNeeded)
     (lsp-proxy-remote--handle-deploy-needed msg))
   (when (eql method 'emacs/remoteDeployProgress)
-    (lsp-proxy-remote--handle-deploy-progress msg))))
+    (lsp-proxy-remote--handle-deploy-progress msg)))
 
 (defun lsp-proxy--handle-request (_ method msg)
   "Handle MSG of type METHOD."

--- a/lsp-proxy-core.el
+++ b/lsp-proxy-core.el
@@ -18,6 +18,7 @@
 (require 'jsonrpc)
 (require 'dash)
 (require 'lsp-proxy-utils)
+(require 'lsp-proxy-remote)
 
 (defcustom lsp-proxy-log-file-directory temporary-file-directory
   "The directory for `lsp-proxy' server to generate log file."
@@ -313,7 +314,8 @@ Only sends requests if servers are available."
                                                                 "--log" lsp-proxy--log-file
                                                                 "--max-item" (number-to-string lsp-proxy-max-completion-item)
                                                                 "--max-diagnostics-push" (number-to-string lsp-proxy-diagnostics-max-push-count)
-                                                                "--copilot-server-name" lsp-proxy-copilot-server-name)
+                                                                "--copilot-server-name" lsp-proxy-copilot-server-name
+                                                                "--remote-binary-path" lsp-proxy-remote-binary-path)
                                                           (when lsp-proxy-enable-bytecode '("--bytecode")))
                                          :connection-type 'pipe
                                          :stderr (get-buffer-create "*lsp proxy stderr*")

--- a/lsp-proxy-core.el
+++ b/lsp-proxy-core.el
@@ -178,6 +178,23 @@ This is used to determine if LSP requests should be sent.")
   (and lsp-proxy--connection
        (jsonrpc-running-p lsp-proxy--connection)))
 
+(defun lsp-proxy--connection-process (connection)
+  "Return the process backing CONNECTION, if any."
+  (when connection
+    (ignore-errors
+      (jsonrpc--process connection))))
+
+(defun lsp-proxy--wait-process-exit (process timeout)
+  "Wait up to TIMEOUT seconds for PROCESS to exit.
+Return non-nil when PROCESS is no longer live."
+  (let ((deadline (+ (float-time) timeout)))
+    (while (and (processp process)
+                (process-live-p process)
+                (< (float-time) deadline))
+      (accept-process-output process 0.05))
+    (not (and (processp process)
+              (process-live-p process)))))
+
 (defun lsp-proxy--ensure-connection ()
   "Ensure connection is established."
   (unless (lsp-proxy--connection-alivep)
@@ -550,11 +567,26 @@ Records BEG, END and PRE-CHANGE-LENGTH locally."
 (defun lsp-proxy-restart ()
   "Restart."
   (interactive)
-  (unwind-protect
-      (progn
-        (lsp-proxy--request 'shutdown (lsp-proxy--build-params nil) :timeout 1.5)
-        (jsonrpc-notify lsp-proxy--connection 'exit (lsp-proxy--build-params nil)))
-    (jsonrpc-shutdown lsp-proxy--connection)
+  (let* ((connection lsp-proxy--connection)
+         (process (lsp-proxy--connection-process connection)))
+    (when (and connection (jsonrpc-running-p connection))
+      ;; `shutdown' and `exit' are server-lifecycle operations, not
+      ;; document-scoped.  Bypass the `lsp-proxy--has-any-servers' and
+      ;; `lsp-proxy-mode' guards by calling jsonrpc directly so these are
+      ;; always delivered regardless of the current buffer state.
+      (ignore-errors
+        (jsonrpc-request connection 'shutdown
+                         (list :params nil) :timeout 1.5))
+      (ignore-errors
+        (jsonrpc-notify connection 'exit (list :params nil)))
+      ;; Give the Rust server a chance to run its `exit' handler.  That handler
+      ;; synchronously kills remote SSH transports before calling
+      ;; `process::exit'.  Calling `jsonrpc-shutdown' immediately can delete the
+      ;; local process before it handles `exit', leaving remote servers alive.
+      (unless (and (processp process)
+                   (lsp-proxy--wait-process-exit process 3.0))
+        (ignore-errors
+          (jsonrpc-shutdown connection))))
     (setq lsp-proxy--connection nil))
   (lsp-proxy--cleanup)
   (lsp-proxy--on-doc-focus (selected-window))

--- a/lsp-proxy-core.el
+++ b/lsp-proxy-core.el
@@ -136,7 +136,6 @@ This is used to determine if LSP requests should be sent.")
 (declare-function eglot--TextDocumentIdentifier "ext:eglot")
 (declare-function eglot--VersionedTextDocumentIdentifier "ext:eglot")
 (declare-function eglot--widening "ext:eglot")
-(declare-function eglot--apply-workspace-edit "ext:eglot")
 (declare-function lsp-proxy-org-babel-send-src-block-to-lsp-server "lsp-proxy-org")
 (declare-function lsp-proxy-org-babel-monitor-after-change "lsp-proxy-org")
 
@@ -399,7 +398,7 @@ Only sends requests if servers are available."
   "Handle MSG of type METHOD."
   (when (eql method 'workspace/applyEdit)
     (lsp-proxy--dbind (:edit edit) msg
-      (eglot--apply-workspace-edit edit last-command)))
+      (lsp-proxy--apply-workspace-edit edit last-command)))
   (when (eql method 'eslint/openDoc)
     (lsp-proxy--dbind (:url url) msg
       (browse-url url))))

--- a/lsp-proxy-core.el
+++ b/lsp-proxy-core.el
@@ -389,7 +389,11 @@ Only sends requests if servers are available."
         (pcase kind
           ("begin" (lsp-proxy--set-work-done-token (lsp-proxy--fix-path-casing (lsp-proxy--normalize-path root-path)) token value))
           ("report" (lsp-proxy--set-work-done-token (lsp-proxy--fix-path-casing (lsp-proxy--normalize-path root-path)) token value))
-          ("end" (lsp-proxy--rem-work-done-token (lsp-proxy--fix-path-casing (lsp-proxy--normalize-path root-path)) token)))))))
+          ("end" (lsp-proxy--rem-work-done-token (lsp-proxy--fix-path-casing (lsp-proxy--normalize-path root-path)) token))))))
+  (when (eql method 'emacs/remoteDeployNeeded)
+    (lsp-proxy-remote--handle-deploy-needed msg))
+  (when (eql method 'emacs/remoteDeployProgress)
+    (lsp-proxy-remote--handle-deploy-progress msg))))
 
 (defun lsp-proxy--handle-request (_ method msg)
   "Handle MSG of type METHOD."

--- a/lsp-proxy-core.el
+++ b/lsp-proxy-core.el
@@ -453,7 +453,7 @@ Records BEG, END and PRE-CHANGE-LENGTH locally."
   (when (and lsp-proxy-mode (eq window (selected-window)))
     (if lsp-proxy--buffer-opened
         (lsp-proxy--notify ':textDocument/didFocus
-                           (list :textDocument (eglot--TextDocumentIdentifier)))
+                           (list :textDocument (lsp-proxy--TextDocumentIdentifier)))
       (lsp-proxy--on-doc-open))))
 
 (defun lsp-proxy--get-initial-content ()
@@ -486,7 +486,7 @@ Records BEG, END and PRE-CHANGE-LENGTH locally."
             (if is-large-file
                 (setq-local lsp-proxy--support-document-highlight nil))
             (lsp-proxy--notify 'textDocument/didOpen
-                               (list :textDocument (append (eglot--TextDocumentIdentifier)
+                               (list :textDocument (append (lsp-proxy--TextDocumentIdentifier)
                                                            (list
                                                             :text initial-content
                                                             :languageId lsp-proxy--language
@@ -503,19 +503,19 @@ Records BEG, END and PRE-CHANGE-LENGTH locally."
   "Notify that the document has been closed."
   (when (and lsp-proxy--buffer-opened buffer-file-name)
     (lsp-proxy--notify 'textDocument/didClose
-                       (list :textDocument (eglot--TextDocumentIdentifier)))
+                       (list :textDocument (lsp-proxy--TextDocumentIdentifier)))
     (setq-local lsp-proxy--buffer-opened nil)))
 
 (defun lsp-proxy--will-save ()
   "Send textDocument/willSave notification."
   (lsp-proxy--notify 'textDocument/willSave
                      ;; 1 Manual, 2 AfterDelay, 3 FocusOut
-                     (list :textDocument (eglot--TextDocumentIdentifier) :reason 1)))
+                     (list :textDocument (lsp-proxy--TextDocumentIdentifier) :reason 1)))
 
 (defun lsp-proxy--did-save ()
   "Send textDocument/didSave notification."
   (lsp-proxy--notify 'textDocument/didSave
-                     (list :textDocument (eglot--TextDocumentIdentifier)))
+                     (list :textDocument (lsp-proxy--TextDocumentIdentifier)))
   (setq-local lsp-proxy--skip-auto-open nil))
 
 (defun lsp-proxy--send-did-change ()

--- a/lsp-proxy-core.el
+++ b/lsp-proxy-core.el
@@ -178,23 +178,6 @@ This is used to determine if LSP requests should be sent.")
   (and lsp-proxy--connection
        (jsonrpc-running-p lsp-proxy--connection)))
 
-(defun lsp-proxy--connection-process (connection)
-  "Return the process backing CONNECTION, if any."
-  (when connection
-    (ignore-errors
-      (jsonrpc--process connection))))
-
-(defun lsp-proxy--wait-process-exit (process timeout)
-  "Wait up to TIMEOUT seconds for PROCESS to exit.
-Return non-nil when PROCESS is no longer live."
-  (let ((deadline (+ (float-time) timeout)))
-    (while (and (processp process)
-                (process-live-p process)
-                (< (float-time) deadline))
-      (accept-process-output process 0.05))
-    (not (and (processp process)
-              (process-live-p process)))))
-
 (defun lsp-proxy--ensure-connection ()
   "Ensure connection is established."
   (unless (lsp-proxy--connection-alivep)
@@ -564,33 +547,44 @@ Records BEG, END and PRE-CHANGE-LENGTH locally."
       (setq lsp-proxy--recent-changes nil))))
 
 ;;; Commands
+(defun lsp-proxy--shutdown-server ()
+  "Send shutdown + exit to the running lsp-proxy server and wait for it to die.
+Does NOT restart or reconnect.  Safe to call from `kill-emacs-hook'."
+  (let ((connection lsp-proxy--connection))
+    (when (and connection (jsonrpc-running-p connection))
+      ;; Bypass `lsp-proxy--has-any-servers' / `lsp-proxy-mode' guards: these
+      ;; are server-lifecycle messages, not document-scoped requests.
+      (ignore-errors
+        (jsonrpc-request connection 'shutdown (list :params nil) :timeout 1.5))
+      (ignore-errors
+        (jsonrpc-notify connection 'exit (list :params nil)))
+      ;; Wait up to 3s for the Rust process to handle `exit' (which
+      ;; synchronously kills remote SSH connections before calling
+      ;; process::exit).  If it doesn't exit in time, force-kill it.
+      (let ((proc (ignore-errors (jsonrpc--process connection)))
+            (deadline (+ (float-time) 3.0)))
+        (when (processp proc)
+          (while (and (process-live-p proc) (< (float-time) deadline))
+            (accept-process-output proc 0.05)))
+        (when (and (processp proc) (process-live-p proc))
+          (ignore-errors (jsonrpc-shutdown connection)))))
+    (setq lsp-proxy--connection nil)))
+
 (defun lsp-proxy-restart ()
   "Restart."
   (interactive)
-  (let* ((connection lsp-proxy--connection)
-         (process (lsp-proxy--connection-process connection)))
-    (when (and connection (jsonrpc-running-p connection))
-      ;; `shutdown' and `exit' are server-lifecycle operations, not
-      ;; document-scoped.  Bypass the `lsp-proxy--has-any-servers' and
-      ;; `lsp-proxy-mode' guards by calling jsonrpc directly so these are
-      ;; always delivered regardless of the current buffer state.
-      (ignore-errors
-        (jsonrpc-request connection 'shutdown
-                         (list :params nil) :timeout 1.5))
-      (ignore-errors
-        (jsonrpc-notify connection 'exit (list :params nil)))
-      ;; Give the Rust server a chance to run its `exit' handler.  That handler
-      ;; synchronously kills remote SSH transports before calling
-      ;; `process::exit'.  Calling `jsonrpc-shutdown' immediately can delete the
-      ;; local process before it handles `exit', leaving remote servers alive.
-      (unless (and (processp process)
-                   (lsp-proxy--wait-process-exit process 3.0))
-        (ignore-errors
-          (jsonrpc-shutdown connection))))
-    (setq lsp-proxy--connection nil))
+  (lsp-proxy--shutdown-server)
   (lsp-proxy--cleanup)
   (lsp-proxy--on-doc-focus (selected-window))
   (message "[LSP-PROXY] Process restarted."))
+
+(defun lsp-proxy--kill-emacs-hook ()
+  "Clean up lsp-proxy remote servers before Emacs exits.
+Added to `kill-emacs-hook' so remote emacs-lsp-proxy processes are
+terminated even when Emacs exits without calling `lsp-proxy-restart'."
+  (lsp-proxy--shutdown-server))
+
+(add-hook 'kill-emacs-hook #'lsp-proxy--kill-emacs-hook)
 
 (defun lsp-proxy-open-log-file ()
   "Open the log file. If it does not exist, create it first."

--- a/lsp-proxy-core.el
+++ b/lsp-proxy-core.el
@@ -304,7 +304,11 @@ Only sends requests if servers are available."
                   :name "lsp proxy"
                   :notification-dispatcher #'lsp-proxy--handle-notification
                   :request-dispatcher #'lsp-proxy--handle-request
-                  :process (make-process :name "lsp proxy agent"
+                  :process (let ((process-environment
+                                  (cons (format "LSP_PROXY_REMOTE_BINARY_PATH=%s"
+                                                lsp-proxy-remote-binary-path)
+                                        process-environment)))
+                              (make-process :name "lsp proxy agent"
                                          :coding 'utf-8-emacs-unix
                                          :command (append (list lsp-proxy--exec-file
                                                                 "--stdio"
@@ -313,12 +317,11 @@ Only sends requests if servers are available."
                                                                 "--log" lsp-proxy--log-file
                                                                 "--max-item" (number-to-string lsp-proxy-max-completion-item)
                                                                 "--max-diagnostics-push" (number-to-string lsp-proxy-diagnostics-max-push-count)
-                                                                "--copilot-server-name" lsp-proxy-copilot-server-name
-                                                                "--remote-binary-path" lsp-proxy-remote-binary-path)
+                                                                "--copilot-server-name" lsp-proxy-copilot-server-name)
                                                           (when lsp-proxy-enable-bytecode '("--bytecode")))
                                          :connection-type 'pipe
                                          :stderr (get-buffer-create "*lsp proxy stderr*")
-                                         :noquery t))))
+                                         :noquery t)))))
     (condition-case nil
         (funcall make-fn :events-buffer-config `(:size ,lsp-proxy-log-max))
       (invalid-slot-name

--- a/lsp-proxy-diagnostics.el
+++ b/lsp-proxy-diagnostics.el
@@ -348,7 +348,7 @@ When FULL is non-nil, request all diagnostics without limit."
     (lsp-proxy--async-request
      'textDocument/diagnostic
      (lsp-proxy--build-params
-      (list :textDocument (eglot--TextDocumentIdentifier))
+      (list :textDocument (lsp-proxy--TextDocumentIdentifier))
       `(:context (:limitDiagnostics ,(if full :json-false t))))
      :timeout-fn #'ignore)))
 

--- a/lsp-proxy-imenu.el
+++ b/lsp-proxy-imenu.el
@@ -30,7 +30,7 @@ Returns a list as described in docstring of `imenu--index-alist'."
     (cl-return-from lsp-proxy-imenu))
   (let* ((res (lsp-proxy--request 'textDocument/documentSymbol
                                   (lsp-proxy--build-params
-                                   (list :textDocument (eglot--TextDocumentIdentifier)))
+                                   (list :textDocument (lsp-proxy--TextDocumentIdentifier)))
                                   :cancel-on-input non-essential)))
     (lsp-proxy--convert-imenu-format res)))
 

--- a/lsp-proxy-inlay-hints.el
+++ b/lsp-proxy-inlay-hints.el
@@ -159,7 +159,7 @@ Update the range of `(FROM TO)'."
     (lsp-proxy--async-request
      'textDocument/inlayHint
      (lsp-proxy--build-params
-      (list :textDocument (eglot--TextDocumentIdentifier)
+      (list :textDocument (lsp-proxy--TextDocumentIdentifier)
             :range (list :start (eglot--pos-to-lsp-position from)
                          :end (eglot--pos-to-lsp-position to))))
      :success-fn (lambda (hints)

--- a/lsp-proxy-inline-completion.el
+++ b/lsp-proxy-inline-completion.el
@@ -169,7 +169,7 @@ To work around posn problems with after-string property.")
       (lsp-proxy--async-request
        'textDocument/inlineCompletion
        (lsp-proxy--build-params
-        (append (eglot--TextDocumentPositionParams)
+        (append (lsp-proxy--TextDocumentPositionParams)
                 `(:context (:triggerKind ,(if implicit 2 1))))
         `(:context
           (:triggerKind ,(if implicit 2 1)

--- a/lsp-proxy-org.el
+++ b/lsp-proxy-org.el
@@ -258,7 +258,7 @@ The server side will handle didClose if needed when reusing servers."
           (setq-local lsp-proxy-org-babel--saved-trigger-characters
                       lsp-proxy--completion-trigger-characters))
         (lsp-proxy--notify 'textDocument/didOpen
-                           (list :textDocument (append (eglot--TextDocumentIdentifier)
+                           (list :textDocument (append (lsp-proxy--TextDocumentIdentifier)
                                                        (list
                                                         :text (org-element-property :value lsp-proxy-org-babel--info-cache)
                                                         :languageId normalized-language

--- a/lsp-proxy-remote.el
+++ b/lsp-proxy-remote.el
@@ -145,6 +145,35 @@ Behaviour depends on `lsp-proxy-remote-deploy-mode':
   "Handle `emacs/remoteDeployProgress' notification with PARAMS."
   (lsp-proxy-remote--log (plist-get params :message)))
 
+;;; TRAMP host candidates
+
+(defun lsp-proxy-remote--tramp-ssh-keys ()
+  "Return a deduplicated list of SSH host candidates for deploy completion.
+Candidates are collected by calling every completion function registered
+for the `ssh' method via `tramp-get-completion-function', which covers:
+ - historical connections (`tramp-parse-connection-properties')
+ - ~/.ssh/config  (`tramp-parse-sconfig')
+ - ~/.ssh/known_hosts (`tramp-parse-shosts')
+ - /etc/hosts.equiv, auth-sources, etc.
+Each entry has the form `[user@]host' matching lsp-proxy's connection key."
+  (when (fboundp 'tramp-get-completion-function)
+    (let (keys)
+      (dolist (spec (tramp-get-completion-function "ssh"))
+        (let* ((fn  (car spec))
+               (arg (cadr spec))
+               (pairs (ignore-errors
+                        (if arg (funcall fn arg) (funcall fn)))))
+          (dolist (pair pairs)
+            (let ((user (car pair))
+                  (host (cadr pair)))
+              (when (and host (not (string-empty-p host)))
+                (cl-pushnew
+                 (if (and user (not (string-empty-p user)))
+                     (concat user "@" host)
+                   host)
+                 keys :test #'equal))))))
+      (nreverse keys))))
+
 ;;; Interactive deploy command
 
 ;;;###autoload
@@ -158,8 +187,10 @@ the upload begins.
 
 When called interactively, defaults to the host that last requested a deploy."
   (interactive
-   (list (read-string
+   (list (completing-read
           "Remote host (connection key): "
+          (lsp-proxy-remote--tramp-ssh-keys)
+          nil nil
           lsp-proxy-remote--pending-connection-key)))
   (unless (and connection-key (not (string-empty-p connection-key)))
     (user-error "No connection key specified"))

--- a/lsp-proxy-remote.el
+++ b/lsp-proxy-remote.el
@@ -10,10 +10,12 @@
 ;;; Commentary:
 
 ;; Remote development configuration for lsp-proxy.
-;; Provides customization options for connecting to and deploying the
-;; lsp-proxy server on remote hosts via SSH.
+;; Provides customization options, notification handlers and an interactive
+;; deploy command for working with remote hosts via TRAMP/SSH.
 
 ;;; Code:
+
+(require 'lsp-proxy-utils)
 
 (defgroup lsp-proxy-remote nil
   "Remote development settings for lsp-proxy."
@@ -22,13 +24,196 @@
 
 (defcustom lsp-proxy-remote-binary-path "~/.cache/emacs/lsp-proxy/emacs-lsp-proxy"
   "Path on the remote host where the emacs-lsp-proxy binary is installed.
-When lsp-proxy opens a TRAMP buffer, it auto-deploys its own binary to
-this path on the remote host if the binary is absent or outdated.
 The path is interpreted by the remote shell, so `~' is expanded on the
 remote side.  Change this if your remote home directory is not writable
 or you prefer a different installation location."
   :type 'string
   :group 'lsp-proxy-remote)
+
+(defcustom lsp-proxy-remote-deploy-mode 'manual
+  "How lsp-proxy handles a missing or outdated remote binary.
+
+`manual' (default) — when the binary check fails, lsp-proxy prints a
+  message and waits.  Run `M-x lsp-proxy-remote-deploy' to open the
+  deploy buffer, review check results, confirm, and start the upload.
+
+`auto' — lsp-proxy automatically starts the deploy as soon as the check
+  fails, streaming progress to the `*lsp-proxy-deploy*' buffer so you
+  can follow along.  No confirmation prompt is shown."
+  :type '(choice (const :tag "Manual (prompt before deploying)" manual)
+                 (const :tag "Auto (deploy immediately, show progress)" auto))
+  :group 'lsp-proxy-remote)
+
+;;; Internal state
+
+(defvar lsp-proxy-remote--deploy-buffer-name "*lsp-proxy-deploy*"
+  "Name of the buffer used to display remote deploy progress.")
+
+(defvar lsp-proxy-remote--pending-connection-key nil
+  "Connection key of the most recent host that requested a deploy.")
+
+;;; Deploy buffer helpers
+
+(defun lsp-proxy-remote--deploy-buffer ()
+  "Return the deploy progress buffer, creating it if necessary."
+  (get-buffer-create lsp-proxy-remote--deploy-buffer-name))
+
+(defun lsp-proxy-remote--log (msg)
+  "Append MSG with a timestamp to the deploy progress buffer."
+  (with-current-buffer (lsp-proxy-remote--deploy-buffer)
+    (goto-char (point-max))
+    (insert (format-time-string "[%H:%M:%S] ") msg "\n")))
+
+(defun lsp-proxy-remote--show-deploy-buffer ()
+  "Pop up the deploy progress buffer without switching focus."
+  (display-buffer (lsp-proxy-remote--deploy-buffer)
+                  '((display-buffer-at-bottom)
+                    (window-height . 12))))
+
+(defun lsp-proxy-remote--reset-deploy-buffer (connection-key mode-label)
+  "Clear the deploy buffer and write an opening header for CONNECTION-KEY.
+MODE-LABEL is a short string describing the current deploy mode (e.g.
+\"auto\" or \"manual\") shown in the header."
+  (with-current-buffer (lsp-proxy-remote--deploy-buffer)
+    (let ((inhibit-read-only t))
+      (erase-buffer)
+      (insert (format "Deploy log — %s  [%s]  (started %s)\n%s\n\n"
+                      connection-key
+                      mode-label
+                      (format-time-string "%Y-%m-%d %H:%M:%S")
+                      (make-string 60 ?-)))))
+  (lsp-proxy-remote--show-deploy-buffer))
+
+;;; Internal: run the actual upload
+
+(defun lsp-proxy-remote--do-deploy (connection-key)
+  "Send the deploy request for CONNECTION-KEY and stream progress to the buffer."
+  (lsp-proxy-remote--log "")
+  (lsp-proxy-remote--log "Starting upload...")
+  (lsp-proxy--async-request
+   'emacs/deployRemoteBinary
+   (lsp-proxy--build-params (list :connectionKey connection-key))
+   :success-fn
+   (lambda (result)
+     (let ((ok   (eq (plist-get result :success) t))
+           (msg  (plist-get result :message))
+           (path (plist-get result :binaryPath)))
+       (lsp-proxy-remote--log "")
+       (lsp-proxy-remote--log
+        (if ok
+            (format "✓ Deploy succeeded. Binary: %s" (or path ""))
+          (format "✗ Deploy failed: %s" msg)))
+       (lsp-proxy-remote--show-deploy-buffer)
+       (if ok
+           (message "[lsp-proxy] Deploy succeeded. Re-open the remote file to connect.")
+         (message "[lsp-proxy] Deploy failed — see %s for details."
+                  lsp-proxy-remote--deploy-buffer-name))))
+   :error-fn
+   (lambda (err)
+     (lsp-proxy-remote--log (format "✗ Error: %s" err))
+     (lsp-proxy-remote--show-deploy-buffer)
+     (message "[lsp-proxy] Deploy error — see %s for details."
+              lsp-proxy-remote--deploy-buffer-name))))
+
+;;; Notification handlers (called from lsp-proxy-core notification dispatcher)
+
+(defun lsp-proxy-remote--handle-deploy-needed (params)
+  "Handle `emacs/remoteDeployNeeded' notification with PARAMS.
+Behaviour depends on `lsp-proxy-remote-deploy-mode':
+- `manual': show a minibuffer hint pointing to `lsp-proxy-remote-deploy'.
+- `auto':   start the deploy immediately, streaming progress to the buffer."
+  (let* ((key        (plist-get params :connectionKey))
+         (reason     (plist-get params :reason))
+         (local-ver  (plist-get params :localVersion))
+         (deploy-path (plist-get params :deployPath)))
+    (setq lsp-proxy-remote--pending-connection-key key)
+    (pcase lsp-proxy-remote-deploy-mode
+      ('manual
+       (message
+        (concat "[lsp-proxy] Remote binary unavailable on %s (%s). "
+                "Run M-x lsp-proxy-remote-deploy to deploy v%s to %s.")
+        key reason local-ver deploy-path))
+      ('auto
+       (lsp-proxy-remote--reset-deploy-buffer key "auto")
+       (lsp-proxy-remote--log
+        (format "Binary unavailable (%s). Starting automatic deploy of v%s..."
+                reason local-ver))
+       (lsp-proxy-remote--log (format "Target path: %s" deploy-path))
+       (lsp-proxy-remote--do-deploy key)))))
+
+(defun lsp-proxy-remote--handle-deploy-progress (params)
+  "Handle `emacs/remoteDeployProgress' notification with PARAMS."
+  (lsp-proxy-remote--log (plist-get params :message)))
+
+;;; Interactive deploy command
+
+;;;###autoload
+(defun lsp-proxy-remote-deploy (connection-key)
+  "Check and optionally deploy emacs-lsp-proxy to the remote host CONNECTION-KEY.
+
+Opens `*lsp-proxy-deploy*' showing the check result for both the global
+command and the deploy path.  If a matching binary is already available
+the command stops there.  Otherwise the user is asked to confirm before
+the upload begins.
+
+When called interactively, defaults to the host that last requested a deploy."
+  (interactive
+   (list (read-string
+          "Remote host (connection key): "
+          lsp-proxy-remote--pending-connection-key)))
+  (unless (and connection-key (not (string-empty-p connection-key)))
+    (user-error "No connection key specified"))
+  (lsp-proxy-remote--reset-deploy-buffer connection-key "manual")
+  (lsp-proxy-remote--log "Checking remote binary...")
+  (lsp-proxy--async-request
+   'emacs/checkRemoteBinary
+   (lsp-proxy--build-params (list :connectionKey connection-key))
+   :success-fn
+   (lambda (result)
+     (let* ((local-ver   (plist-get result :localVersion))
+            (deploy-path (plist-get result :deployPath))
+            (available   (plist-get result :availableBinary))
+            (global      (plist-get result :global))
+            (path-info   (plist-get result :path))
+            (g-status    (plist-get global    :status))
+            (g-version   (plist-get global    :version))
+            (p-status    (plist-get path-info :status))
+            (p-version   (plist-get path-info :version)))
+       (lsp-proxy-remote--log "")
+       (lsp-proxy-remote--log (format "Local version : %s" local-ver))
+       (lsp-proxy-remote--log (format "Deploy path   : %s" deploy-path))
+       (lsp-proxy-remote--log "")
+       (lsp-proxy-remote--log
+        (format "Global command (emacs-lsp-proxy): %s"
+                (pcase g-status
+                  ("match"            (format "✓ v%s — up to date" g-version))
+                  ("version_mismatch" (format "✗ v%s — version mismatch" g-version))
+                  (_                  "✗ not found in PATH"))))
+       (lsp-proxy-remote--log
+        (format "Deploy path   (%s): %s"
+                deploy-path
+                (pcase p-status
+                  ("match"            (format "✓ v%s — up to date" p-version))
+                  ("version_mismatch" (format "✗ v%s — version mismatch" p-version))
+                  (_                  "✗ not found"))))
+       (lsp-proxy-remote--log "")
+       (if available
+           (progn
+             (lsp-proxy-remote--log
+              (format "✓ Binary available at %s — no deploy needed." available))
+             (lsp-proxy-remote--show-deploy-buffer)
+             (message "[lsp-proxy] Remote binary is up to date on %s." connection-key))
+         (lsp-proxy-remote--log "Binary not available or outdated. Deploy required.")
+         (lsp-proxy-remote--show-deploy-buffer)
+         (when (yes-or-no-p
+                (format "[lsp-proxy] Deploy v%s to %s? " local-ver connection-key))
+           (lsp-proxy-remote--do-deploy connection-key)))))
+   :error-fn
+   (lambda (err)
+     (lsp-proxy-remote--log (format "✗ Check failed: %s" err))
+     (lsp-proxy-remote--show-deploy-buffer)
+     (message "[lsp-proxy] Binary check failed — see %s."
+              lsp-proxy-remote--deploy-buffer-name))))
 
 (provide 'lsp-proxy-remote)
 ;;; lsp-proxy-remote.el ends here

--- a/lsp-proxy-remote.el
+++ b/lsp-proxy-remote.el
@@ -1,0 +1,34 @@
+;;; lsp-proxy-remote.el --- Remote development support for lsp-proxy -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2023-2025 JadeStrong
+
+;; Author: JadeStrong <jadestrong@163.com>
+;; Keywords: tools, languages
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Remote development configuration for lsp-proxy.
+;; Provides customization options for connecting to and deploying the
+;; lsp-proxy server on remote hosts via SSH.
+
+;;; Code:
+
+(defgroup lsp-proxy-remote nil
+  "Remote development settings for lsp-proxy."
+  :prefix "lsp-proxy-remote-"
+  :group 'lsp-proxy)
+
+(defcustom lsp-proxy-remote-binary-path "~/.cache/emacs/lsp-proxy/emacs-lsp-proxy"
+  "Path on the remote host where the emacs-lsp-proxy binary is installed.
+When lsp-proxy opens a TRAMP buffer, it auto-deploys its own binary to
+this path on the remote host if the binary is absent or outdated.
+The path is interpreted by the remote shell, so `~' is expanded on the
+remote side.  Change this if your remote home directory is not writable
+or you prefer a different installation location."
+  :type 'string
+  :group 'lsp-proxy-remote)
+
+(provide 'lsp-proxy-remote)
+;;; lsp-proxy-remote.el ends here

--- a/lsp-proxy-remote.el
+++ b/lsp-proxy-remote.el
@@ -17,6 +17,29 @@
 
 (require 'lsp-proxy-utils)
 
+;;; Low-level request helper
+;;
+;; `lsp-proxy--async-request' gates every send behind `lsp-proxy--has-any-servers',
+;; which is only set after a file is opened with lsp-proxy-mode active.
+;; Remote-management requests (check, deploy) are not document-scoped and must
+;; reach the server regardless, so we bypass that guard and call
+;; `jsonrpc-async-request' directly.
+(cl-defun lsp-proxy-remote--async-request (method params &rest args
+                                           &key
+                                           (success-fn #'ignore)
+                                           (error-fn   (lambda (err)
+                                                         (message "[lsp-proxy] %s" err)))
+                                           &allow-other-keys)
+  "Send a server-management async request without the has-any-servers guard."
+  (apply #'jsonrpc-async-request
+         lsp-proxy--connection
+         method params
+         :success-fn success-fn
+         :error-fn   error-fn
+         (cl-loop for (k v) on args by #'cddr
+                  unless (memq k '(:success-fn :error-fn))
+                  append (list k v))))
+
 (defgroup lsp-proxy-remote nil
   "Remote development settings for lsp-proxy."
   :prefix "lsp-proxy-remote-"
@@ -90,9 +113,9 @@ MODE-LABEL is a short string describing the current deploy mode (e.g.
   "Send the deploy request for CONNECTION-KEY and stream progress to the buffer."
   (lsp-proxy-remote--log "")
   (lsp-proxy-remote--log "Starting upload...")
-  (lsp-proxy--async-request
+  (lsp-proxy-remote--async-request
    'emacs/deployRemoteBinary
-   (lsp-proxy--build-params (list :connectionKey connection-key))
+   (list :params (list :connectionKey connection-key))
    :success-fn
    (lambda (result)
      (let ((ok   (eq (plist-get result :success) t))
@@ -145,6 +168,18 @@ Behaviour depends on `lsp-proxy-remote-deploy-mode':
   "Handle `emacs/remoteDeployProgress' notification with PARAMS."
   (lsp-proxy-remote--log (plist-get params :message)))
 
+;;; Remote info query
+
+;;;###autoload
+(defun lsp-proxy-remote-get-info (success-fn)
+  "Query the server for remote connection status and call SUCCESS-FN with the result.
+Bypasses the `lsp-proxy--has-any-servers' guard so it works even when no
+buffer has `lsp-proxy-mode' active."
+  (lsp-proxy-remote--async-request
+   'emacs/getRemoteInfo
+   (list :params nil)
+   :success-fn success-fn))
+
 ;;; TRAMP host candidates
 
 (defun lsp-proxy-remote--tramp-ssh-keys ()
@@ -194,11 +229,17 @@ When called interactively, defaults to the host that last requested a deploy."
           lsp-proxy-remote--pending-connection-key)))
   (unless (and connection-key (not (string-empty-p connection-key)))
     (user-error "No connection key specified"))
+  ;; Ensure the local lsp-proxy server is running — the deploy requests are
+  ;; sent through it regardless of whether lsp-proxy-mode is active in any
+  ;; buffer.
+  (lsp-proxy--ensure-connection)
   (lsp-proxy-remote--reset-deploy-buffer connection-key "manual")
-  (lsp-proxy-remote--log "Checking remote binary...")
-  (lsp-proxy--async-request
+  (lsp-proxy-remote--log
+   (concat "Checking remote binary on " connection-key
+           "  (may take a moment while establishing SSH connection)..."))
+  (lsp-proxy-remote--async-request
    'emacs/checkRemoteBinary
-   (lsp-proxy--build-params (list :connectionKey connection-key))
+   (list :params (list :connectionKey connection-key))
    :success-fn
    (lambda (result)
      (let* ((local-ver   (plist-get result :localVersion))

--- a/lsp-proxy-signature.el
+++ b/lsp-proxy-signature.el
@@ -24,7 +24,7 @@
       (lsp-proxy--async-request
        'textDocument/signatureHelp
        (lsp-proxy--build-params
-        (eglot--TextDocumentPositionParams))
+        (lsp-proxy--TextDocumentPositionParams))
        :success-fn
        (eglot--lambda ((SignatureHelp)
                        signatures activeSignature (activeParameter 0))

--- a/lsp-proxy-utils.el
+++ b/lsp-proxy-utils.el
@@ -184,6 +184,35 @@ If the system is not Windows, return the original path."
 
 (declare-function w32-long-file-name "w32proc.c" (fn))
 
+(defun lsp-proxy--path-to-uri (path)
+  "Convert PATH to an LSP `file://' URI.
+Unlike `eglot-path-to-uri', this preserves a TRAMP prefix (`/ssh:host:')
+rather than stripping it. lsp-proxy's Rust backend uses that prefix as
+the sole signal for routing the request to a remote LSP server; if we
+let eglot drop it, every buffer looks local and remote mode never
+engages."
+  (let ((remote-prefix (and path (file-remote-p path))))
+    (if remote-prefix
+        (concat "file://"
+                remote-prefix
+                (url-hexify-string
+                 (substring path (length remote-prefix))
+                 url-path-allowed-chars))
+      (concat "file://"
+              (if (eq system-type 'windows-nt) "/" "")
+              (url-hexify-string path url-path-allowed-chars)))))
+
+(defun lsp-proxy--TextDocumentIdentifier ()
+  "Build a TextDocumentIdentifier for the current buffer.
+Drop-in replacement for `eglot--TextDocumentIdentifier' that uses
+`lsp-proxy--path-to-uri', so TRAMP-rooted buffers produce URIs the
+Rust-side remote router can recognise."
+  (let ((path (or buffer-file-name
+                  (ignore-errors (buffer-file-name (buffer-base-buffer))))))
+    (unless path
+      (error "lsp-proxy: buffer has no file name"))
+    (list :uri (lsp-proxy--path-to-uri path))))
+
 (defun lsp-proxy--uri-to-path (uri)
   "Convert URI to file path."
   (when (keywordp uri) (setq uri (substring (symbol-name uri) 1)))
@@ -276,7 +305,7 @@ virtual document sent to the language server."
                    args
                  ;; Otherwise, flatten as before
                  (apply 'append args)))
-         (base-params (append (eglot--TextDocumentIdentifier)
+         (base-params (append (lsp-proxy--TextDocumentIdentifier)
                               `(:params ,params)
                               rest))
          (virtual-doc (lsp-proxy--make-virtual-doc-context)))

--- a/lsp-proxy-utils.el
+++ b/lsp-proxy-utils.el
@@ -417,5 +417,90 @@ Only works when mode is `tick or `alive."
       (when lsp-proxy-mode
         (run-hooks 'lsp-proxy-on-idle-hook)))))
 
+(defun lsp-proxy--propose-changes-as-diff (prepared)
+  "Helper for `lsp-proxy--apply-workspace-edit'.
+Goal is to popup a `diff-mode' buffer containing all the changes
+of PREPARED, ready to apply with C-c C-a.  PREPARED is a
+list ((FILENAME EDITS VERSION)...)."
+  (with-current-buffer (get-buffer-create "*EGLOT proposed server changes*")
+    (buffer-disable-undo (current-buffer))
+    (let ((inhibit-read-only t)
+          (target (current-buffer)))
+      (diff-mode)
+      (erase-buffer)
+      (pcase-dolist (`(,path ,edits ,_) prepared)
+        (with-temp-buffer
+          (let* ((diff (current-buffer))
+                 (existing-buf (find-buffer-visiting path))
+                 (existing-buf-label (prin1-to-string existing-buf)))
+            (with-temp-buffer
+              (if existing-buf
+                  (insert-buffer-substring existing-buf)
+                (insert-file-contents path))
+              (eglot--apply-text-edits edits nil t)
+              (diff-no-select (or existing-buf path) (current-buffer) nil t diff)
+              (when existing-buf
+                ;; Here we have to pretend the label of the unsaved
+                ;; buffer is the actual file, just so that we can
+                ;; diff-apply without troubles.  If there's a better
+                ;; way, it probably involves changes to `diff.el'.
+                (with-current-buffer diff
+                  (goto-char (point-min))
+                  (while (search-forward existing-buf-label nil t)
+                    (replace-match (buffer-file-name existing-buf))))))
+            (with-current-buffer target
+              (insert-buffer-substring diff))))))
+    (setq-local buffer-read-only t)
+    (buffer-enable-undo (current-buffer))
+    (goto-char (point-min))
+    (pop-to-buffer (current-buffer))
+    (font-lock-ensure)))
+
+(defun lsp-proxy--apply-workspace-edit (wedit origin)
+  "Apply (or offer to apply) the workspace edit WEDIT.
+ORIGIN is a symbol designating the command that originated this
+edit proposed by the server."
+  (eglot--dbind ((WorkspaceEdit) changes documentChanges) wedit
+    (let ((prepared
+           (mapcar (eglot--lambda ((TextDocumentEdit) textDocument edits)
+                     (eglot--dbind ((VersionedTextDocumentIdentifier) uri version)
+                         textDocument
+                       (list (eglot-uri-to-path uri) edits version)))
+                   documentChanges)))
+      (unless (and changes documentChanges)
+        ;; We don't want double edits, and some servers send both
+        ;; changes and documentChanges.  This unless ensures that we
+        ;; prefer documentChanges over changes.
+        (cl-loop for (uri edits) on changes by #'cddr
+                 do (push (list (eglot-uri-to-path uri) edits) prepared)))
+      (cl-flet ((notevery-visited-p ()
+                  (cl-notevery #'find-buffer-visiting
+                               (mapcar #'car prepared)))
+                (accept-p ()
+                  (y-or-n-p
+                   (format "[eglot] Server wants to edit:\n%sProceed? "
+                           (cl-loop
+                            for (f eds _) in prepared
+                            concat (format
+                                    "  %s (%d change%s)\n"
+                                    f (length eds)
+                                    (if (> (length eds) 1) "s" ""))))))
+                (apply ()
+                  (cl-loop for edit in prepared
+                   for (path edits version) = edit
+                   do (with-current-buffer (find-file-noselect path)
+                        (eglot--apply-text-edits edits version))
+                   finally (eldoc) (eglot--message "Edit successful!"))))
+        (let ((decision (eglot--confirm-server-edits origin prepared)))
+          (cond
+           ((or (eq decision 'diff)
+                (and (eq decision 'maybe-diff) (notevery-visited-p)))
+            (lsp-proxy--propose-changes-as-diff prepared))
+           ((or (memq decision '(t summary))
+                (and (eq decision 'maybe-summary) (notevery-visited-p)))
+            (when (accept-p) (apply)))
+           (t
+            (apply))))))))
+
 (provide 'lsp-proxy-utils)
 ;;; lsp-proxy-utils.el ends here

--- a/lsp-proxy-utils.el
+++ b/lsp-proxy-utils.el
@@ -465,14 +465,14 @@ edit proposed by the server."
            (mapcar (eglot--lambda ((TextDocumentEdit) textDocument edits)
                      (eglot--dbind ((VersionedTextDocumentIdentifier) uri version)
                          textDocument
-                       (list (eglot-uri-to-path uri) edits version)))
+                       (list (lsp-proxy--uri-to-path uri) edits version)))
                    documentChanges)))
       (unless (and changes documentChanges)
         ;; We don't want double edits, and some servers send both
         ;; changes and documentChanges.  This unless ensures that we
         ;; prefer documentChanges over changes.
         (cl-loop for (uri edits) on changes by #'cddr
-                 do (push (list (eglot-uri-to-path uri) edits) prepared)))
+                 do (push (list (lsp-proxy--uri-to-path uri) edits) prepared)))
       (cl-flet ((notevery-visited-p ()
                   (cl-notevery #'find-buffer-visiting
                                (mapcar #'car prepared)))

--- a/lsp-proxy-utils.el
+++ b/lsp-proxy-utils.el
@@ -235,23 +235,34 @@ Rust remote router can dispatch the request."
         :position (eglot--pos-to-lsp-position)))
 
 (defun lsp-proxy--uri-to-path (uri)
-  "Convert URI to file path."
+  "Convert URI to file path.
+When the URI's path already carries a TRAMP method marker (`/ssh:' or
+`/rpc:') the Rust backend preserved the remote identity in the URI
+itself — we must NOT glue the project's own remote-prefix on top, or
+the path ends up with the method/host segment doubled (which then
+fails to open on the remote FS)."
   (when (keywordp uri) (setq uri (substring (symbol-name uri) 1)))
-  (let* ((remote-prefix (and lsp-proxy--current-project-root (file-remote-p lsp-proxy--current-project-root)))
+  (let* ((remote-prefix (and lsp-proxy--current-project-root
+                             (file-remote-p lsp-proxy--current-project-root)))
          (url (url-generic-parse-url uri)))
-    ;; Only parse file:// URIs, leave other URI untouched as
+    ;; Only parse file:// URIs, leave other URIs untouched as
     ;; `file-name-handler-alist' should know how to handle them
     ;; (bug#58790).
     (if (string= "file" (url-type url))
         (let* ((retval (url-unhex-string (url-filename url)))
+               (already-tramp (or (string-prefix-p "/ssh:" retval)
+                                  (string-prefix-p "/rpc:" retval)))
                ;; Remove the leading "/" for local MS Windows-style paths.
                (normalized (if (and (not remote-prefix)
+                                    (not already-tramp)
                                     (eq system-type 'windows-nt)
                                     (cl-plusp (length retval))
                                     (eq (aref retval 0) ?/))
                                (w32-long-file-name (substring retval 1))
                              retval)))
-          (concat remote-prefix normalized))
+          (if already-tramp
+              normalized
+            (concat remote-prefix normalized)))
       uri)))
 
 ;;; Snippet expansion

--- a/lsp-proxy-utils.el
+++ b/lsp-proxy-utils.el
@@ -213,6 +213,27 @@ Rust-side remote router can recognise."
       (error "lsp-proxy: buffer has no file name"))
     (list :uri (lsp-proxy--path-to-uri path))))
 
+(defun lsp-proxy--VersionedTextDocumentIdentifier ()
+  "Build a VersionedTextDocumentIdentifier for the current buffer.
+Mirrors `eglot--VersionedTextDocumentIdentifier' but routes the URI
+through `lsp-proxy--path-to-uri' so TRAMP prefixes survive.
+Reads the version directly from the eglot-side buffer-local variables
+to avoid a circular require on `lsp-proxy-core'."
+  (let ((version (cond ((boundp 'eglot--docver) eglot--docver)
+                       ((boundp 'eglot--versioned-identifier)
+                        eglot--versioned-identifier)
+                       (t 0))))
+    (append (lsp-proxy--TextDocumentIdentifier)
+            (list :version version))))
+
+(defun lsp-proxy--TextDocumentPositionParams ()
+  "Build a TextDocumentPositionParams for the current buffer + point.
+Mirrors `eglot--TextDocumentPositionParams' but the embedded URI goes
+through `lsp-proxy--path-to-uri', keeping TRAMP prefixes intact so the
+Rust remote router can dispatch the request."
+  (list :textDocument (lsp-proxy--TextDocumentIdentifier)
+        :position (eglot--pos-to-lsp-position)))
+
 (defun lsp-proxy--uri-to-path (uri)
   "Convert URI to file path."
   (when (keywordp uri) (setq uri (substring (symbol-name uri) 1)))

--- a/lsp-proxy-xref.el
+++ b/lsp-proxy-xref.el
@@ -383,8 +383,8 @@ If RETURN-RESULTS is non-nil, return the xref items instead of showing them."
 This version returns xref objects suitable for xref backend methods.
 EXTRA-PARAMS will be appended to the basic TextDocumentPositionParams."
   (when-let* ((params (if extra-params
-                          (append (eglot--TextDocumentPositionParams) extra-params)
-                        (eglot--TextDocumentPositionParams)))
+                          (append (lsp-proxy--TextDocumentPositionParams) extra-params)
+                        (lsp-proxy--TextDocumentPositionParams)))
               (response (lsp-proxy--request 
                          method 
                          (lsp-proxy--build-params params))))
@@ -395,7 +395,7 @@ EXTRA-PARAMS will be appended to the basic TextDocumentPositionParams."
   (interactive)
   (lsp-proxy--async-request
    'textDocument/definition
-   (lsp-proxy--build-params (eglot--TextDocumentPositionParams))
+   (lsp-proxy--build-params (lsp-proxy--TextDocumentPositionParams))
    :success-fn #'lsp-proxy--process-locations))
 
 (defun lsp-proxy-find-references ()
@@ -404,7 +404,7 @@ EXTRA-PARAMS will be appended to the basic TextDocumentPositionParams."
   (lsp-proxy--async-request
    'textDocument/references
    (lsp-proxy--build-params
-    (append (eglot--TextDocumentPositionParams) `(:context (:includeDeclaration t))))
+    (append (lsp-proxy--TextDocumentPositionParams) `(:context (:includeDeclaration t))))
    :success-fn #'lsp-proxy--process-locations))
 
 (defun lsp-proxy-find-declaration ()
@@ -412,7 +412,7 @@ EXTRA-PARAMS will be appended to the basic TextDocumentPositionParams."
   (interactive)
   (lsp-proxy--async-request
    'textDocument/declaration
-   (lsp-proxy--build-params (eglot--TextDocumentPositionParams))
+   (lsp-proxy--build-params (lsp-proxy--TextDocumentPositionParams))
    :success-fn #'lsp-proxy--process-locations))
 
 (defun lsp-proxy-find-type-definition ()
@@ -420,7 +420,7 @@ EXTRA-PARAMS will be appended to the basic TextDocumentPositionParams."
   (interactive)
   (lsp-proxy--async-request
    'textDocument/typeDefinition
-   (lsp-proxy--build-params (eglot--TextDocumentPositionParams))
+   (lsp-proxy--build-params (lsp-proxy--TextDocumentPositionParams))
    :success-fn #'lsp-proxy--process-locations))
 
 (defun lsp-proxy-find-implementations ()
@@ -428,7 +428,7 @@ EXTRA-PARAMS will be appended to the basic TextDocumentPositionParams."
   (interactive)
   (lsp-proxy--async-request
    'textDocument/implementation
-   (lsp-proxy--build-params (eglot--TextDocumentPositionParams))
+   (lsp-proxy--build-params (lsp-proxy--TextDocumentPositionParams))
    :success-fn #'lsp-proxy--process-locations))
 
 (provide 'lsp-proxy-xref)

--- a/lsp-proxy.el
+++ b/lsp-proxy.el
@@ -190,7 +190,7 @@
   (let ((orig-major-mode major-mode))
     (lsp-proxy--async-request
      'rust-analyzer/expandMacro
-     (lsp-proxy--build-params (eglot--TextDocumentPositionParams))
+     (lsp-proxy--build-params (lsp-proxy--TextDocumentPositionParams))
      :success-fn
      (lambda (resp)
        (-if-let* ((expansion (plist-get resp :expansion))
@@ -599,7 +599,7 @@ Request codeAction/resolve for more info if server supports."
   (lsp-proxy--async-request
    'textDocument/rename
    (lsp-proxy--build-params
-    (append (eglot--TextDocumentPositionParams) `(:newName ,newname)))
+    (append (lsp-proxy--TextDocumentPositionParams) `(:newName ,newname)))
    :success-fn (lambda (edits)
                  (if edits
                      (eglot--apply-workspace-edit edits this-command)
@@ -697,7 +697,7 @@ Request codeAction/resolve for more info if server supports."
   (interactive)
   (lsp-proxy--async-request
    'textDocument/hover
-   (lsp-proxy--build-params (eglot--TextDocumentPositionParams))
+   (lsp-proxy--build-params (lsp-proxy--TextDocumentPositionParams))
    :success-fn (lambda (hover-help)
                  (if (and hover-help (not (equal hover-help "")))
                      (with-current-buffer (get-buffer-create lsp-proxy-hover-buffer)
@@ -715,7 +715,7 @@ Request codeAction/resolve for more info if server supports."
     (let ((buf (current-buffer)))
       (lsp-proxy--async-request
        'textDocument/hover
-       (lsp-proxy--build-params (eglot--TextDocumentPositionParams))
+       (lsp-proxy--build-params (lsp-proxy--TextDocumentPositionParams))
        :success-fn (lambda (hover-help)
                      (eglot--when-buffer-window buf
                        (let* ((info (unless (string-empty-p hover-help)
@@ -759,7 +759,7 @@ most recently requested highlights.")
         (setq lsp-proxy--symbol-bounds-of-last-highlight-invocation curr-sym-bounds)
         (lsp-proxy--async-request
          'textDocument/documentHighlight
-         (lsp-proxy--build-params (eglot--TextDocumentPositionParams))
+         (lsp-proxy--build-params (lsp-proxy--TextDocumentPositionParams))
          :success-fn
          (lambda (highlights)
            (mapc #'delete-overlay lsp-proxy--highlights)

--- a/lsp-proxy.el
+++ b/lsp-proxy.el
@@ -422,10 +422,7 @@ Skip reopening notifications for buffers not currently visible."
 
       ;; Remote connection status
       (when (lsp-proxy--connection-alivep)
-        (lsp-proxy--async-request
-         'emacs/getRemoteInfo
-         (lsp-proxy--build-params nil)
-         :success-fn
+        (lsp-proxy-remote-get-info
          (lambda (status)
            (with-current-buffer debug-buffer
              (insert "\n=== Remote Connection Status ===\n")

--- a/lsp-proxy.el
+++ b/lsp-proxy.el
@@ -581,7 +581,7 @@ Skip reopening notifications for buffers not currently visible."
          (command (plist-get item :command))
          (edit (plist-get item :edit)))
     (when edit
-      (eglot--apply-workspace-edit edit this-command))
+      (lsp-proxy--apply-workspace-edit edit this-command))
     (when command
       (lsp-proxy--execute-command (plist-get command :command) (plist-get command :arguments) ls-id))))
 
@@ -634,7 +634,7 @@ Request codeAction/resolve for more info if server supports."
     (append (lsp-proxy--TextDocumentPositionParams) `(:newName ,newname)))
    :success-fn (lambda (edits)
                  (if edits
-                     (eglot--apply-workspace-edit edits this-command)
+                     (lsp-proxy--apply-workspace-edit edits this-command)
                    (lsp-proxy--warn "%s" "Server does not support rename.")))))
 
 ;;; Document formatting

--- a/lsp-proxy.el
+++ b/lsp-proxy.el
@@ -515,7 +515,7 @@ Skip reopening notifications for buffers not currently visible."
    'textDocument/codeAction
    (lsp-proxy--build-params
     (list
-     :textDocument (eglot--TextDocumentIdentifier)
+     :textDocument (lsp-proxy--TextDocumentIdentifier)
      :range (if (use-region-p)
                 (lsp-proxy--region-range (region-beginning) (region-end))
               (lsp-proxy--region-range (point) (point)))
@@ -677,7 +677,7 @@ Request codeAction/resolve for more info if server supports."
                :trimTrailingWhitespace lsp-proxy-trim-trailing-whitespace
                :insertFinalNewline lsp-proxy-insert-final-newline
                :trimFinalNewlines lsp-proxy-trim-final-newlines)
-     :textDocument (eglot--TextDocumentIdentifier)))
+     :textDocument (lsp-proxy--TextDocumentIdentifier)))
    :success-fn (lambda (edits)
                  (when (buffer-live-p (current-buffer))
                    (if (and edits (> (length edits) 0))

--- a/lsp-proxy.el
+++ b/lsp-proxy.el
@@ -420,6 +420,38 @@ Skip reopening notifications for buffers not currently visible."
                                   (plist-get diag :message))))
               (insert "No diagnostics found\n")))))
 
+      ;; Remote connection status
+      (when (lsp-proxy--connection-alivep)
+        (lsp-proxy--async-request
+         'emacs/getRemoteInfo
+         (lsp-proxy--build-params nil)
+         :success-fn
+         (lambda (status)
+           (with-current-buffer debug-buffer
+             (insert "\n=== Remote Connection Status ===\n")
+             (let ((enabled (eq (plist-get status :enabled) t))
+                   (clients (plist-get status :clients)))
+               (insert (format "Remote Enabled: %s\n" (if enabled "Yes" "No")))
+               (if (and clients (> (length clients) 0))
+                   (progn
+                     (insert (format "Active Clients: %d\n\n" (length clients)))
+                     (seq-doseq (client clients)
+                       (let ((key (plist-get client :connectionKey))
+                             (rtype (plist-get client :remoteType))
+                             (alive (eq (plist-get client :isAlive) t))
+                             (binary-path (plist-get client :binaryPath))
+                             (local-ver (plist-get client :localVersion))
+                             (remote-ver (plist-get client :remoteVersion))
+                             (deploy (plist-get client :deployStatus)))
+                         (insert (format "  [%s] %s (%s)\n"
+                                         (if alive "ALIVE" "DEAD")
+                                         key rtype))
+                         (insert (format "    Binary Path:    %s\n" (or binary-path "N/A")))
+                         (insert (format "    Deploy Status:  %s\n" (or deploy "unknown")))
+                         (insert (format "    Local Version:  %s\n" (or local-ver "N/A")))
+                         (insert (format "    Remote Version: %s\n" (or remote-ver "N/A"))))))
+                 (insert "No remote clients connected\n")))))))
+
       ;; Languages configuration
       (when (lsp-proxy--connection-alivep)
         (lsp-proxy--async-request

--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+
+package lsp_proxy.rpc;
+
+// Top-level wire envelope. Every message on the wire is exactly one Envelope
+// framed by a 4-byte little-endian length prefix.
+message Envelope {
+  // Correlation id. Required for Request/Response, optional for Notification.
+  optional uint32 id = 1;
+  // When this envelope is a Response to a request we initiated, echo the
+  // original request id so the client can route the response.
+  optional uint32 responding_to = 2;
+
+  oneof payload {
+    Request request = 3;
+    Response response = 4;
+    Notification notification = 5;
+  }
+}
+
+message Request {
+  // LSP method name, e.g. "textDocument/definition".
+  string method = 1;
+  // JSON-encoded LSP params.
+  bytes params = 2;
+}
+
+message Response {
+  // JSON-encoded LSP result. Mutually exclusive with `error`.
+  optional bytes result = 1;
+  optional RpcError error = 2;
+}
+
+message Notification {
+  string method = 1;
+  bytes params = 2;
+}
+
+message RpcError {
+  int32 code = 1;
+  string message = 2;
+  optional bytes data = 3;
+}

--- a/src/application.rs
+++ b/src/application.rs
@@ -8,6 +8,24 @@ use crate::{
 use crossbeam_channel::Sender;
 use std::{sync::Arc, sync::Mutex, time::Instant};
 
+/// A hook registered by the Controller to kill remote processes synchronously
+/// before `process::exit()`.  Stored as a global so it is reachable from the
+/// Application thread without requiring a shared Arc between the two threads.
+static EXIT_HOOK: std::sync::OnceLock<Box<dyn Fn() + Send + Sync>> =
+    std::sync::OnceLock::new();
+
+/// Register the exit hook.  Called once during Controller initialisation.
+pub fn register_exit_hook(f: impl Fn() + Send + Sync + 'static) {
+    EXIT_HOOK.set(Box::new(f)).ok();
+}
+
+/// Run the exit hook if one was registered.
+pub fn run_exit_hook() {
+    if let Some(hook) = EXIT_HOOK.get() {
+        hook();
+    }
+}
+
 pub(crate) type ReqHandler = fn(&mut Application, Response);
 type ReqQueue = req_queue::ReqQueue<(String, Instant), ReqHandler>;
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -93,7 +93,7 @@ impl Application {
             log::debug!("Shutting down language server: {}", client.name());
             // Send shutdown to language servers if they're running
             if client.is_initialized() {
-                let _ = client.shutdown_and_exit();
+                drop(client.shutdown_and_exit());
             }
         }
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -65,11 +65,13 @@ impl Application {
     }
 
     pub(crate) fn complete_request(&mut self, response: Response) {
-        let handler = self
-            .req_queue
-            .outgoing
-            .complete(response.id.clone())
-            .expect("received response for unknown request");
+        let Some(handler) = self.req_queue.outgoing.complete(response.id.clone()) else {
+            log::warn!(
+                "received response for unknown request id={:?}, ignoring",
+                response.id
+            );
+            return;
+        };
         handler(self, response)
     }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -68,6 +68,16 @@ impl Args {
                 _ => anyhow::bail!("unknown argument: {arg}"),
             }
         }
+        // `Args::default()` returns 0 for these; if the flag wasn't passed,
+        // substitute the documented defaults. Without this the remote-server
+        // (started with only --remote-server --log-level) silently truncates
+        // every completion response to 0 items.
+        if args.max_item_num == 0 {
+            args.max_item_num = 20;
+        }
+        if args.max_diagnostics_push == 0 {
+            args.max_diagnostics_push = 50;
+        }
         Ok(args)
     }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -14,6 +14,7 @@ pub struct Args {
     pub max_diagnostics_push: usize,
     pub enable_bytecode: bool,
     pub copilot_server_name: String,
+    pub remote_binary_path: Option<String>,
 }
 
 impl Args {
@@ -53,6 +54,10 @@ impl Args {
                         }
                     }
                     None => args.copilot_server_name = "copilot".to_string(),
+                },
+                "--remote-binary-path" => match argv.next() {
+                    Some(path) => args.remote_binary_path = Some(path),
+                    None => anyhow::bail!("--remote-binary-path must specify a path"),
                 },
                 "--stdio" => args.stdio = true,
                 "--remote-server" => args.remote_server = true,
@@ -96,6 +101,7 @@ impl Args {
         println!("        --max-diagnostics-push <NUM>  Maximum diagnostics to push (default: 50)");
         println!("        --stdio               Enable stdio communication mode (required)");
         println!("        --remote-server       Run as a remote server (reads/writes Protobuf Envelopes on stdio)");
+        println!("        --remote-binary-path <PATH>  Remote host path for the deployed binary (default: ~/.cache/emacs/lsp-proxy/emacs-lsp-proxy)");
         println!("        --bytecode            Enable bytecode optimization for JSON-RPC");
         println!("    -h, --help               Print help information");
         println!("    -V, --version            Print version information");

--- a/src/args.rs
+++ b/src/args.rs
@@ -87,6 +87,7 @@ impl Args {
         println!();
         println!("USAGE:");
         println!("    emacs-lsp-proxy [OPTIONS] --stdio");
+        println!("    emacs-lsp-proxy [OPTIONS] --remote-server");
         println!();
         println!("OPTIONS:");
         println!("    -c, --config <FILE>       Set configuration file path");

--- a/src/args.rs
+++ b/src/args.rs
@@ -7,6 +7,7 @@ pub struct Args {
     pub log_level: u64,
     pub log_file: Option<PathBuf>,
     pub stdio: bool,
+    pub remote_server: bool,
     pub show_help: bool,
     pub show_version: bool,
     pub max_item_num: usize,
@@ -54,6 +55,7 @@ impl Args {
                     None => args.copilot_server_name = "copilot".to_string(),
                 },
                 "--stdio" => args.stdio = true,
+                "--remote-server" => args.remote_server = true,
                 "--bytecode" => args.enable_bytecode = true,
                 "-h" | "--help" => {
                     args.show_help = true;
@@ -83,6 +85,7 @@ impl Args {
         println!("        --max-item <NUM>      Maximum completion items (default: 20)");
         println!("        --max-diagnostics-push <NUM>  Maximum diagnostics to push (default: 50)");
         println!("        --stdio               Enable stdio communication mode (required)");
+        println!("        --remote-server       Run as a remote server (reads/writes Protobuf Envelopes on stdio)");
         println!("        --bytecode            Enable bytecode optimization for JSON-RPC");
         println!("    -h, --help               Print help information");
         println!("    -V, --version            Print version information");

--- a/src/args.rs
+++ b/src/args.rs
@@ -14,7 +14,6 @@ pub struct Args {
     pub max_diagnostics_push: usize,
     pub enable_bytecode: bool,
     pub copilot_server_name: String,
-    pub remote_binary_path: Option<String>,
 }
 
 impl Args {
@@ -54,10 +53,6 @@ impl Args {
                         }
                     }
                     None => args.copilot_server_name = "copilot".to_string(),
-                },
-                "--remote-binary-path" => match argv.next() {
-                    Some(path) => args.remote_binary_path = Some(path),
-                    None => anyhow::bail!("--remote-binary-path must specify a path"),
                 },
                 "--stdio" => args.stdio = true,
                 "--remote-server" => args.remote_server = true,
@@ -101,7 +96,7 @@ impl Args {
         println!("        --max-diagnostics-push <NUM>  Maximum diagnostics to push (default: 50)");
         println!("        --stdio               Enable stdio communication mode (required)");
         println!("        --remote-server       Run as a remote server (reads/writes Protobuf Envelopes on stdio)");
-        println!("        --remote-binary-path <PATH>  Remote host path for the deployed binary (default: ~/.cache/emacs/lsp-proxy/emacs-lsp-proxy)");
+        println!("        LSP_PROXY_REMOTE_BINARY_PATH  env var: remote host path for the deployed binary");
         println!("        --bytecode            Enable bytecode optimization for JSON-RPC");
         println!("    -h, --help               Print help information");
         println!("    -V, --version            Print version information");

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -27,8 +27,8 @@ impl FromStr for LispObject {
             Ok(Self::Nil)
         } else if s == "t" {
             Ok(Self::T)
-        } else if s.starts_with(":") {
-            Ok(Self::Keyword(s[1..].to_string()))
+        } else if let Some(stripped) = s.strip_prefix(':') {
+            Ok(Self::Keyword(stripped.to_string()))
         } else {
             bail!("Supported LispObject: {s}")
         }
@@ -77,7 +77,7 @@ impl LispObject {
                         127 => result += "\\d",
                         27 => result += "\\e",
                         // NOTE: do not use 0..=7 in this branch, because it takes one more byte than the next branch
-                        8..=26 => {
+                        14..=26 => {
                             // \^@ \^A \^B ... \^Z
                             result += &format!("\\^{}", (*c as u32 + 64) as u8 as char);
                         }
@@ -193,7 +193,7 @@ impl Op {
             Self::Call(v) => Ok(smallvec![(32 + 7) as u8, (v & 0xff) as u8, (v >> 8) as u8]),
             Self::StackRef(v) if (1..=4).contains(&v) => Ok(smallvec![v as u8]),
             Self::StackRef(_) => unimplemented!(),
-            Self::List(v) if v == 0 => unreachable!(),
+            Self::List(0) => unreachable!(),
             Self::List(v) if (1..=4).contains(&v) => Ok(smallvec![66 + v]),
             Self::List(v) => Ok(smallvec![175, v]),
             Self::Discard => Ok(smallvec![136]),

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,8 @@ use std::{fs, path::PathBuf, str::from_utf8};
 
 static CONFIG_FILE: once_cell::sync::OnceCell<PathBuf> = once_cell::sync::OnceCell::new();
 static LOG_FILE: once_cell::sync::OnceCell<PathBuf> = once_cell::sync::OnceCell::new();
+static LOG_LEVEL: once_cell::sync::OnceCell<u64> = once_cell::sync::OnceCell::new();
+static REMOTE_SERVER_MODE: once_cell::sync::OnceCell<bool> = once_cell::sync::OnceCell::new();
 pub static MAX_COMPLETION_ITEMS: once_cell::sync::OnceCell<usize> =
     once_cell::sync::OnceCell::new();
 pub static MAX_DIAGNOSTICS_PUSH: once_cell::sync::OnceCell<usize> =
@@ -46,6 +48,16 @@ pub fn initialize_config_file(specified_file: Option<PathBuf>) {
 }
 
 pub fn default_log_file() -> PathBuf {
+    // In --remote-server mode, put the log next to the binary so whoever
+    // deploys it knows where to grep — the user's $HOME cache tree may not
+    // even exist yet on a freshly-provisioned remote.
+    if is_remote_server_mode() {
+        if let Ok(exe) = std::env::current_exe() {
+            if let Some(dir) = exe.parent() {
+                return dir.join("remote-server.log");
+            }
+        }
+    }
     let strategy = choose_base_strategy().expect("Unable to find the cache directory!");
     let mut path = strategy.cache_dir();
     path.push("lsp-proxy");
@@ -60,6 +72,25 @@ pub fn initialize_log_file(specified_file: Option<PathBuf>) {
 
 pub fn log_file() -> PathBuf {
     LOG_FILE.get().map(|path| path.to_path_buf()).unwrap()
+}
+
+pub fn set_log_level(level: u64) {
+    LOG_LEVEL.set(level).ok();
+}
+
+/// Current log verbosity (0 = warn, 1 = info, 2 = debug, 3 = trace).
+/// Used by the remote-dispatch code to forward the same level to the
+/// remote-server process so its log isn't empty by default.
+pub fn log_level() -> u64 {
+    *LOG_LEVEL.get().unwrap_or(&0)
+}
+
+pub fn set_remote_server_mode(flag: bool) {
+    REMOTE_SERVER_MODE.set(flag).ok();
+}
+
+pub fn is_remote_server_mode() -> bool {
+    *REMOTE_SERVER_MODE.get().unwrap_or(&false)
 }
 
 fn default_lang_config() -> toml::Value {

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,10 +53,29 @@ pub fn remote_binary_path() -> &'static str {
 }
 
 pub fn initialize_config_file(specified_file: Option<PathBuf>) {
-    // check specified file exist and is file, then set CONFIG_FILE
+    // Explicit --config flag takes priority.
     if let Some(file) = specified_file {
         if file.exists() && file.is_file() {
             CONFIG_FILE.set(file).unwrap();
+        }
+        return;
+    }
+
+    // In --remote-server mode, fall back to `languages.toml` beside the binary
+    // so operators can drop a config file next to the deployed binary without
+    // having to pass --config explicitly.
+    if is_remote_server_mode() {
+        if let Ok(exe) = std::env::current_exe() {
+            if let Some(dir) = exe.parent() {
+                let candidate = dir.join("languages.toml");
+                if candidate.is_file() {
+                    debug!(
+                        "remote-server: using languages.toml beside binary: {}",
+                        candidate.display()
+                    );
+                    CONFIG_FILE.set(candidate).ok();
+                }
+            }
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,9 @@ pub static ENABLE_BYTECODE: once_cell::sync::OnceCell<bool> = once_cell::sync::O
 pub static COPILOT_SERVER_NAME: once_cell::sync::OnceCell<String> =
     once_cell::sync::OnceCell::new();
 
+static REMOTE_BINARY_PATH: once_cell::sync::OnceCell<String> =
+    once_cell::sync::OnceCell::new();
+
 pub fn set_max_completion_items(max_items: usize) {
     MAX_COMPLETION_ITEMS.set(max_items).ok();
 }
@@ -38,6 +41,17 @@ pub fn set_copilot_server_name(name: String) {
     COPILOT_SERVER_NAME.set(name).ok();
 }
 
+pub fn set_remote_binary_path(path: String) {
+    REMOTE_BINARY_PATH.set(path).ok();
+}
+
+pub fn remote_binary_path() -> &'static str {
+    REMOTE_BINARY_PATH
+        .get()
+        .map(|s| s.as_str())
+        .unwrap_or(crate::remote::deploy::DEFAULT_REMOTE_BINARY_PATH)
+}
+
 pub fn initialize_config_file(specified_file: Option<PathBuf>) {
     // check specified file exist and is file, then set CONFIG_FILE
     if let Some(file) = specified_file {
@@ -54,7 +68,7 @@ pub fn default_log_file() -> PathBuf {
     if is_remote_server_mode() {
         if let Ok(exe) = std::env::current_exe() {
             if let Some(dir) = exe.parent() {
-                return dir.join("remote-server.log");
+                return dir.join(format!("remote-server-{}.log", timestamp_now()));
             }
         }
     }
@@ -141,4 +155,14 @@ pub fn default_syntax_loader() -> syntax::Configuration {
         }
     };
     config
+}
+
+/// Format the current local time as `YYYYMMDD-HHMMSS`, falling back to UTC.
+fn timestamp_now() -> String {
+    use time::macros::format_description;
+    let fmt = format_description!("[year][month][day]-[hour][minute][second]");
+    let now = time::OffsetDateTime::now_local()
+        .unwrap_or_else(|_| time::OffsetDateTime::now_utc());
+    now.format(fmt)
+        .unwrap_or_else(|_| "00000000-000000".to_string())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,8 +41,15 @@ pub fn set_copilot_server_name(name: String) {
     COPILOT_SERVER_NAME.set(name).ok();
 }
 
-pub fn set_remote_binary_path(path: String) {
-    REMOTE_BINARY_PATH.set(path).ok();
+/// Initialise the remote binary path from the `LSP_PROXY_REMOTE_BINARY_PATH`
+/// environment variable.  Call once at startup, before the remote manager is
+/// used.  If the variable is absent or empty the built-in default is used.
+pub fn initialize_remote_binary_path() {
+    if let Ok(val) = std::env::var("LSP_PROXY_REMOTE_BINARY_PATH") {
+        if !val.is_empty() {
+            REMOTE_BINARY_PATH.set(val).ok();
+        }
+    }
 }
 
 pub fn remote_binary_path() -> &'static str {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -52,6 +52,13 @@ pub struct IoThreads {
 }
 
 impl IoThreads {
+    pub fn new(
+        reader: thread::JoinHandle<io::Result<()>>,
+        writer: thread::JoinHandle<io::Result<()>>,
+    ) -> Self {
+        Self { reader, writer }
+    }
+
     pub fn join(self) -> io::Result<()> {
         match self.reader.join() {
             Ok(r) => r?,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,10 +1,42 @@
 use crate::msg::Message;
 use crossbeam_channel::{bounded, Receiver, Sender};
-use log::{debug, error};
+use log::{debug, error, warn};
 use std::{
     io::{self, stdin, stdout},
     thread,
 };
+
+/// Force fd 0 (stdin) back to blocking mode.
+///
+/// `tokio::process::Command`'s pre-exec fd plumbing can leave fd 0 with
+/// `O_NONBLOCK` set on Unix, which makes subsequent blocking `read`s return
+/// `EAGAIN` (errno 35). Our stdio reader thread uses blocking reads, so clear
+/// the flag before the first read and every time we recover from an error.
+#[cfg(unix)]
+fn force_stdin_blocking() {
+    use std::os::unix::io::AsRawFd;
+    let fd = io::stdin().as_raw_fd();
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFL);
+        if flags < 0 {
+            warn!("stdio reader: F_GETFL failed on stdin: {}", io::Error::last_os_error());
+            return;
+        }
+        if (flags & libc::O_NONBLOCK) != 0 {
+            if libc::fcntl(fd, libc::F_SETFL, flags & !libc::O_NONBLOCK) < 0 {
+                warn!(
+                    "stdio reader: failed to clear O_NONBLOCK on stdin: {}",
+                    io::Error::last_os_error()
+                );
+            } else {
+                debug!("stdio reader: cleared O_NONBLOCK on stdin");
+            }
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn force_stdin_blocking() {}
 
 pub struct Connection {
     pub sender: Sender<Message>,
@@ -27,6 +59,7 @@ impl Connection {
         });
         let (reader_sender, reader_receiver) = bounded::<Message>(0);
         let reader = thread::spawn(move || {
+            force_stdin_blocking();
             let stdin = stdin();
             let mut stdin = stdin.lock();
             loop {
@@ -40,6 +73,13 @@ impl Connection {
                     Ok(None) => {
                         debug!("stdio reader: EOF on stdin, exiting");
                         return Ok(());
+                    }
+                    Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                        // Something flipped fd 0 into non-blocking after we
+                        // cleared it — most commonly a tokio::process::Command
+                        // spawn racing us. Restore blocking mode and retry.
+                        warn!("stdio reader: stdin went non-blocking mid-read; restoring");
+                        force_stdin_blocking();
                     }
                     Err(e) => {
                         error!("stdio reader: read error on stdin: {}", e);

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -66,7 +66,7 @@ impl Connection {
                 match Message::read(&mut stdin) {
                     Ok(Some(msg)) => {
                         if let Err(e) = reader_sender.send(msg) {
-                            error!("stdio reader: inbox receiver dropped: {}", e);
+                            error!("stdio reader: inbox receiver dropped: {e}");
                             return Ok(());
                         }
                     }
@@ -82,7 +82,7 @@ impl Connection {
                         force_stdin_blocking();
                     }
                     Err(e) => {
-                        error!("stdio reader: read error on stdin: {}", e);
+                        error!("stdio reader: read error on stdin: {e}");
                         return Err(e);
                     }
                 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,5 +1,6 @@
 use crate::msg::Message;
 use crossbeam_channel::{bounded, Receiver, Sender};
+use log::{debug, error};
 use std::{
     io::{self, stdin, stdout},
     thread,
@@ -28,12 +29,24 @@ impl Connection {
         let reader = thread::spawn(move || {
             let stdin = stdin();
             let mut stdin = stdin.lock();
-            while let Some(msg) = Message::read(&mut stdin)? {
-                reader_sender
-                    .send(msg)
-                    .expect("receiver was dropped, failed to send a message.");
+            loop {
+                match Message::read(&mut stdin) {
+                    Ok(Some(msg)) => {
+                        if let Err(e) = reader_sender.send(msg) {
+                            error!("stdio reader: inbox receiver dropped: {}", e);
+                            return Ok(());
+                        }
+                    }
+                    Ok(None) => {
+                        debug!("stdio reader: EOF on stdin, exiting");
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        error!("stdio reader: read error on stdin: {}", e);
+                        return Err(e);
+                    }
+                }
             }
-            Ok(())
         });
         let threads = IoThreads { reader, writer };
         (

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -555,6 +555,11 @@ fn spawn_remote_worker(
                     tokio::spawn(async move {
                         match task {
                             RemoteTask::RouteMessage { message } => {
+                                let request_id = if let Message::Request(req) = &message {
+                                    Some(req.id.clone())
+                                } else {
+                                    None
+                                };
                                 match manager.route_message(message).await {
                                     Ok(Some(response)) => {
                                         if let Err(e) = result_tx.send(response) {
@@ -566,6 +571,20 @@ fn spawn_remote_worker(
                                     }
                                     Err(e) => {
                                         error!("remote routing failed: {e}");
+                                        if let Some(id) = request_id {
+                                            let resp = Message::Response(Response {
+                                                id,
+                                                result: None,
+                                                error: Some(crate::lsp::jsonrpc::Error {
+                                                    code: crate::lsp::jsonrpc::ErrorCode::InternalError,
+                                                    message: format!("remote routing failed: {e}"),
+                                                    data: None,
+                                                }),
+                                            });
+                                            if let Err(e) = result_tx.send(resp) {
+                                                warn!("remote result channel closed: {e}");
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -77,6 +77,13 @@ impl Controller {
             }
         };
 
+        // Register a sync exit hook so handle_exit can kill remote processes
+        // before process::exit() — which does not run async Drop chains.
+        if let Some(ref manager) = remote_manager {
+            let m = manager.clone();
+            crate::application::register_exit_hook(move || m.kill_all_sync());
+        }
+
         let (remote_task_tx, remote_result_rx) = match remote_manager.clone() {
             Some(manager) => {
                 let (task_tx, task_rx) = mpsc::unbounded_channel::<RemoteTask>();
@@ -101,6 +108,7 @@ impl Controller {
             remote_result_rx,
         }
     }
+
 
     fn handle_message(&mut self, msg: Message, now: Instant) -> Result<()> {
         // RPC-layer heartbeat from the local RpcClient. Short-circuit before

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use crossbeam_channel::{bounded, select, Receiver, Sender};
 use log::{debug, error, info, warn};
 use lsp_types::notification::Notification;
+use lsp_types::request::Request as _;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::thread;
@@ -41,8 +42,11 @@ pub struct Controller {
 
 /// Unit of work queued to the remote worker thread.
 #[derive(Debug)]
-struct RemoteTask {
-    message: Message,
+enum RemoteTask {
+    /// Forward a message through `RemoteConnectionManager::route_message`.
+    RouteMessage { message: Message },
+    /// Query remote connection status and reply to the given request id.
+    GetRemoteStatus { request_id: msg::RequestId },
 }
 
 impl Controller {
@@ -108,6 +112,37 @@ impl Controller {
             }
         }
 
+        // Remote-info diagnostic query. Needs async access to the remote
+        // manager's tokio Mutexes, so route through the remote worker thread.
+        if let Message::Request(req) = &msg {
+            if req.method == lsp_ext::GetRemoteInfo::METHOD {
+                self.register_request(req, now);
+                if let Some(tx) = &self.remote_task_tx {
+                    if let Err(e) = tx.send(RemoteTask::GetRemoteStatus {
+                        request_id: req.id.clone(),
+                    }) {
+                        error!("remote worker channel closed: {}", e);
+                    }
+                } else {
+                    // No remote manager — return a disabled status directly.
+                    let resp = Response {
+                        id: req.id.clone(),
+                        result: Some(serde_json::to_value(
+                            crate::lsp_ext::RemoteConnectionStatus {
+                                enabled: false,
+                                clients: vec![],
+                            },
+                        ).unwrap()),
+                        error: None,
+                    };
+                    if let Err(e) = self.sender_to_emacs.send(Message::Response(resp)) {
+                        error!("failed to reply to getRemoteInfo: {}", e);
+                    }
+                }
+                return Ok(());
+            }
+        }
+
         // If the remote worker is up and the message targets a remote path,
         // register it and hand it off to the async worker instead of the local
         // LSP pipeline.
@@ -116,7 +151,7 @@ impl Controller {
                 self.register_request(req, now);
             }
             let tx = self.remote_task_tx.as_ref().unwrap();
-            if let Err(e) = tx.send(RemoteTask { message: msg }) {
+            if let Err(e) = tx.send(RemoteTask::RouteMessage { message: msg }) {
                 error!("remote worker channel closed: {}", e);
             }
             return Ok(());
@@ -433,17 +468,32 @@ fn spawn_remote_worker(
                     let manager = manager.clone();
                     let result_tx = result_tx.clone();
                     tokio::spawn(async move {
-                        match manager.route_message(task.message).await {
-                            Ok(Some(response)) => {
-                                if let Err(e) = result_tx.send(response) {
-                                    warn!("remote result channel closed: {}", e);
+                        match task {
+                            RemoteTask::RouteMessage { message } => {
+                                match manager.route_message(message).await {
+                                    Ok(Some(response)) => {
+                                        if let Err(e) = result_tx.send(response) {
+                                            warn!("remote result channel closed: {}", e);
+                                        }
+                                    }
+                                    Ok(None) => {
+                                        debug!("remote worker: notification accepted, no response");
+                                    }
+                                    Err(e) => {
+                                        error!("remote routing failed: {}", e);
+                                    }
                                 }
                             }
-                            Ok(None) => {
-                                debug!("remote worker: notification accepted, no response");
-                            }
-                            Err(e) => {
-                                error!("remote routing failed: {}", e);
+                            RemoteTask::GetRemoteStatus { request_id } => {
+                                let status = manager.get_remote_status().await;
+                                let resp = Message::Response(Response {
+                                    id: request_id,
+                                    result: Some(serde_json::to_value(status).unwrap()),
+                                    error: None,
+                                });
+                                if let Err(e) = result_tx.send(resp) {
+                                    warn!("remote result channel closed: {}", e);
+                                }
                             }
                         }
                     });

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -365,7 +365,7 @@ impl Controller {
                                         .as_ref()
                                         .map(|v| {
                                             let s = v.to_string();
-                                            s[..s.len().min(256)].to_string()
+                                            crate::utils::truncate_preview(&s, 256).to_string()
                                         })
                                         .unwrap_or_else(|| "<none>".into());
                                     debug!(

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -388,6 +388,7 @@ impl Controller {
                         }
                         Err(err) => {
                             warn!("remote worker result channel closed: {err}");
+                            self.remote_result_rx = None;
                         }
                     }
                 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -68,6 +68,10 @@ impl Controller {
             Some(manager) => {
                 let (task_tx, task_rx) = mpsc::unbounded_channel::<RemoteTask>();
                 let (result_tx, result_rx) = bounded::<Message>(64);
+                // Give the manager the same result sink so per-connection
+                // bridges can push server-initiated notifications through
+                // the same select! arm the remote worker uses for Responses.
+                manager.set_result_sink(result_tx.clone());
                 spawn_remote_worker(manager, task_rx, result_tx);
                 (Some(task_tx), Some(result_rx))
             }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,27 +1,48 @@
 use anyhow::Result;
-use crossbeam_channel::{select, Receiver, Sender};
-use log::{debug, error, info};
+use crossbeam_channel::{bounded, select, Receiver, Sender};
+use log::{debug, error, info, warn};
 use lsp_types::notification::Notification;
-use std::time::Instant;
-use tokio::sync::mpsc::UnboundedSender;
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::thread;
+use std::time::Instant;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     lsp_ext,
     msg::{self, Context, Message, Request, Response},
+    remote::RemoteConnectionManager,
     req_queue,
 };
 
 pub(crate) type ReqHandler = fn(Response);
 type ReqQueue = req_queue::ReqQueue<(String, Instant, Request), ReqHandler>;
 
-const REQUEST_WHITELIST: &[&str] = &["textDocument/signatureHelp", "emacs/workspaceRestart", "textDocument/diagnostic"];
+const REQUEST_WHITELIST: &[&str] = &[
+    "textDocument/signatureHelp",
+    "emacs/workspaceRestart",
+    "textDocument/diagnostic",
+];
 
 pub struct Controller {
     sender_for_server: UnboundedSender<Message>,
     sender_to_emacs: Sender<Message>,
     req_queue: ReqQueue,
     processing_requests: HashMap<String, Request>,
+    remote_manager: Option<Arc<RemoteConnectionManager>>,
+    /// Outbound channel into the remote worker thread. If `None`, remote
+    /// routing is disabled and every message goes through the local path.
+    remote_task_tx: Option<mpsc::UnboundedSender<RemoteTask>>,
+    /// Responses/notifications produced by the remote worker. Consumed by the
+    /// main `select!` loop and forwarded to Emacs.
+    remote_result_rx: Option<Receiver<Message>>,
+}
+
+/// Unit of work queued to the remote worker thread.
+#[derive(Debug)]
+struct RemoteTask {
+    message: Message,
 }
 
 impl Controller {
@@ -29,12 +50,120 @@ impl Controller {
         sender_for_server: UnboundedSender<Message>,
         sender_for_emacs: Sender<Message>,
     ) -> Self {
+        let remote_manager = match RemoteConnectionManager::new() {
+            Ok(manager) => {
+                info!("Remote connection manager initialized successfully");
+                Some(Arc::new(manager))
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to initialize remote connection manager: {}. Running in local mode only.",
+                    e
+                );
+                None
+            }
+        };
+
+        let (remote_task_tx, remote_result_rx) = match remote_manager.clone() {
+            Some(manager) => {
+                let (task_tx, task_rx) = mpsc::unbounded_channel::<RemoteTask>();
+                let (result_tx, result_rx) = bounded::<Message>(64);
+                spawn_remote_worker(manager, task_rx, result_tx);
+                (Some(task_tx), Some(result_rx))
+            }
+            None => (None, None),
+        };
+
         Controller {
             sender_for_server,
             sender_to_emacs: sender_for_emacs,
             req_queue: ReqQueue::default(),
             processing_requests: HashMap::new(),
+            remote_manager,
+            remote_task_tx,
+            remote_result_rx,
         }
+    }
+
+    fn handle_message(&mut self, msg: Message, now: Instant) -> Result<()> {
+        // If the remote worker is up and the message targets a remote path,
+        // register it and hand it off to the async worker instead of the local
+        // LSP pipeline.
+        if self.remote_task_tx.is_some() && self.is_remote_message(&msg) {
+            if let Message::Request(ref req) = msg {
+                self.register_request(req, now);
+            }
+            let tx = self.remote_task_tx.as_ref().unwrap();
+            if let Err(e) = tx.send(RemoteTask { message: msg }) {
+                error!("remote worker channel closed: {}", e);
+            }
+            return Ok(());
+        }
+
+        // Local path (unchanged).
+        match msg {
+            Message::Request(req) => {
+                if REQUEST_WHITELIST.contains(&req.method.as_str()) {
+                    self.register_request(&req, now);
+                    self.sender_for_server.send(req.into()).unwrap();
+                } else if !self.processing_requests.contains_key(&req.method) {
+                    debug!(
+                        "No pending request of type {}, register and process {:?}",
+                        req.method, req.id
+                    );
+                    self.register_request(&req, now);
+                    self.processing_requests.insert(req.method.clone(), req.clone());
+                    self.sender_for_server.send(req.into()).unwrap();
+                } else {
+                    debug!(
+                        "Has pending request of type {}, register {:?}",
+                        req.method, req.id
+                    );
+                    self.register_request(&req, now);
+                }
+            }
+            Message::Response(resp) => {
+                self.sender_for_server.send(resp.into()).unwrap();
+            }
+            Message::Notification(not) => {
+                self.sender_for_server.send(not.into()).unwrap();
+            }
+        }
+
+        Ok(())
+    }
+
+    fn is_remote_message(&self, message: &Message) -> bool {
+        if let Some(path) = self.extract_path_from_message(message) {
+            return path.starts_with("/ssh:") || path.starts_with("/rpc:");
+        }
+        false
+    }
+
+    fn extract_path_from_message(&self, message: &Message) -> Option<String> {
+        match message {
+            Message::Request(req) => {
+                if let Some(uri) = &req.params.uri {
+                    Some(uri.clone())
+                } else {
+                    self.extract_uri_from_params(&req.params.params)
+                }
+            }
+            Message::Notification(notif) => self.extract_uri_from_params(&notif.params.params),
+            _ => None,
+        }
+    }
+
+    fn extract_uri_from_params(&self, params: &serde_json::Value) -> Option<String> {
+        if let Some(text_doc) = params.get("textDocument") {
+            if let Some(uri) = text_doc.get("uri") {
+                return uri.as_str().map(|s| s.to_string());
+            }
+        }
+        if let Some(uri) = params.get("uri") {
+            return uri.as_str().map(|s| s.to_string());
+        }
+        None
     }
 
     pub fn run(
@@ -42,32 +171,17 @@ impl Controller {
         inbox: Receiver<Message>,
         receiver_of_server: Receiver<Message>,
     ) -> Result<()> {
+        // `crossbeam::select!` needs a real Receiver. When the remote worker
+        // isn't running, point at a dummy channel that never fires.
+        let (_dummy_tx, dummy_rx) = bounded::<Message>(0);
         loop {
+            let remote_rx = self.remote_result_rx.clone().unwrap_or_else(|| dummy_rx.clone());
             select! {
                 recv(inbox) -> msg => {
                     let now = Instant::now();
                     if let Ok(msg) = msg {
-                        match msg {
-                            Message::Request(req) => {
-                                if REQUEST_WHITELIST.contains(&req.method.as_str()) {
-                                    self.register_request(&req, now);
-                                    self.sender_for_server.send(req.into()).unwrap();
-                                } else if !self.processing_requests.contains_key(&req.method) {
-                                    debug!("No pending request of type {}, register and process {:?}", req.method, req.id);
-                                    self.register_request(&req, now);
-                                    self.processing_requests.insert(req.method.clone(), req.clone());
-                                    self.sender_for_server.send(req.into()).unwrap();
-                                } else {
-                                    debug!("Has pending request of type {}, register {:?}", req.method, req.id);
-                                    self.register_request(&req, now);
-                                }
-                            },
-                            Message::Response(resp) => {
-                                self.sender_for_server.send(resp.into()).unwrap();
-                            },
-                            Message::Notification(not) => {
-                                self.sender_for_server.send(not.into()).unwrap();
-                            },
+                        if let Err(e) = self.handle_message(msg, now) {
+                            error!("Error handling message: {}", e);
                         }
                     } else {
                         error!("inbox error");
@@ -95,6 +209,28 @@ impl Controller {
                         },
                     }
                 }
+                recv(remote_rx) -> msg => {
+                    match msg {
+                        Ok(msg) => {
+                            match msg {
+                                Message::Response(resp) => {
+                                    self.respond(resp);
+                                }
+                                Message::Notification(not) => {
+                                    self.sender_to_emacs.send(not.into()).unwrap();
+                                }
+                                Message::Request(req) => {
+                                    // Server-initiated requests are rare for now;
+                                    // forward verbatim.
+                                    self.sender_to_emacs.send(req.into()).unwrap();
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            warn!("remote worker result channel closed: {}", err);
+                        }
+                    }
+                }
             }
         }
     }
@@ -103,24 +239,23 @@ impl Controller {
         let should_cancel_old = match &request.params.context {
             Some(Context::Completion(new_context)) => {
                 if let Some(old_request) = self.processing_requests.get(&request.method) {
-                    matches!(&old_request.params.context, 
-                        Some(Context::Completion(old_context)) 
+                    matches!(&old_request.params.context,
+                        Some(Context::Completion(old_context))
                         if old_context.prefix.is_empty() && !new_context.prefix.is_empty())
                 } else {
                     false
                 }
             }
-            _ => false
+            _ => false,
         };
 
         if should_cancel_old {
             if let Some(old_request) = self.processing_requests.get(&request.method) {
                 debug!(
                     "{:?} completion request canceled due to new request {:?} with non-empty prefix",
-                    old_request.id,
-                    request.id,
+                    old_request.id, request.id,
                 );
-                
+
                 let cancel_notification = msg::Notification::new(
                     lsp_ext::CustomizeCancel::METHOD.to_string(),
                     lsp_ext::CustomizeCancelParams {
@@ -157,8 +292,10 @@ impl Controller {
 
     pub(crate) fn respond(&mut self, response: Response) {
         let id = response.id.clone();
-        
-        let (method, duration) = if let Some((method, start, _)) = self.req_queue.incoming.complete(&id) {
+
+        let (method, duration) = if let Some((method, start, _)) =
+            self.req_queue.incoming.complete(&id)
+        {
             if let Some(err) = &response.error {
                 if err.message.starts_with("server panicked") {
                     error!("{}, check the log", err.message)
@@ -166,32 +303,30 @@ impl Controller {
             }
 
             let duration = start.elapsed();
-            info!(
-                "handled {} - ({}) in {:0.2?}",
-                method, response.id, duration
-            );
-            
+            info!("handled {} - ({}) in {:0.2?}", method, response.id, duration);
+
             self.sender_to_emacs.send(response.into()).unwrap();
-            
+
             (method, Some(duration))
         } else {
             debug!(
                 "received response({:?}), but request had been canceled",
                 response.id
             );
-            
-            let method = self.processing_requests
+
+            let method = self
+                .processing_requests
                 .iter()
                 .find(|(_, req)| req.id == id)
                 .map(|(method, _)| method.clone());
-                
+
             (method.unwrap_or_default(), None)
         };
 
         if let Some(processing_request) = self.processing_requests.get_mut(&method) {
             if processing_request.id == id {
                 self.processing_requests.remove(&method);
-                
+
                 if duration.is_some() {
                     debug!(
                         "request {} completed in {:?}, processing next request of type {}",
@@ -200,11 +335,9 @@ impl Controller {
                         method
                     );
                 } else {
-                    debug!(
-                        "request {id} was canceled, processing next request of type {method}"
-                    );
+                    debug!("request {id} was canceled, processing next request of type {method}");
                 }
-                
+
                 self.process_next_request_of_type(&method);
             }
         }
@@ -221,11 +354,60 @@ impl Controller {
         };
 
         if let Some(req) = next_request {
-            debug!("processing next request of type {} - id: {:?}", method, req.id);
+            debug!(
+                "processing next request of type {} - id: {:?}",
+                method, req.id
+            );
             self.sender_for_server.send(req.clone().into()).unwrap();
             self.processing_requests.insert(method.to_string(), req);
         } else {
             debug!("no more pending requests of type {method}");
         }
     }
+}
+
+/// Boot a dedicated tokio current-thread runtime that consumes RemoteTasks,
+/// calls `RemoteConnectionManager::route_message`, and pipes results back into
+/// `result_tx` for the controller to forward to Emacs.
+fn spawn_remote_worker(
+    manager: Arc<RemoteConnectionManager>,
+    mut task_rx: mpsc::UnboundedReceiver<RemoteTask>,
+    result_tx: Sender<Message>,
+) {
+    thread::Builder::new()
+        .name("lsp-proxy-remote".into())
+        .spawn(move || {
+            let rt = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(rt) => rt,
+                Err(e) => {
+                    error!("failed to build tokio runtime for remote worker: {}", e);
+                    return;
+                }
+            };
+            rt.block_on(async move {
+                while let Some(task) = task_rx.recv().await {
+                    let manager = manager.clone();
+                    let result_tx = result_tx.clone();
+                    tokio::spawn(async move {
+                        match manager.route_message(task.message).await {
+                            Ok(Some(response)) => {
+                                if let Err(e) = result_tx.send(response) {
+                                    warn!("remote result channel closed: {}", e);
+                                }
+                            }
+                            Ok(None) => {
+                                debug!("remote worker: notification accepted, no response");
+                            }
+                            Err(e) => {
+                                error!("remote routing failed: {}", e);
+                            }
+                        }
+                    });
+                }
+            });
+        })
+        .expect("failed to spawn remote worker thread");
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -223,6 +223,20 @@ impl Controller {
                         Ok(msg) => {
                             match msg {
                                 Message::Response(resp) => {
+                                    let preview = resp
+                                        .result
+                                        .as_ref()
+                                        .map(|v| {
+                                            let s = v.to_string();
+                                            s[..s.len().min(256)].to_string()
+                                        })
+                                        .unwrap_or_else(|| "<none>".into());
+                                    debug!(
+                                        "controller remote response id={:?} error={:?} result_preview={}",
+                                        resp.id,
+                                        resp.error.as_ref().map(|e| &e.message),
+                                        preview
+                                    );
                                     self.respond(resp);
                                 }
                                 Message::Notification(not) => {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -542,6 +542,7 @@ fn spawn_remote_worker(
             rt.block_on(async move {
                 while let Some(task) = task_rx.recv().await {
                     let manager = manager.clone();
+
                     let result_tx = result_tx.clone();
                     tokio::spawn(async move {
                         match task {
@@ -627,6 +628,11 @@ fn spawn_remote_worker(
                         }
                     });
                 }
+                // task_rx exhausted: the controller has been dropped (server
+                // shutdown or restart).  Clean up in the correct order so that
+                // remote processes receive graceful EOF before the ControlMaster
+                // is killed.
+                manager.cleanup().await;
             });
         })
         .expect("failed to spawn remote worker thread");

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -38,6 +38,10 @@ pub struct Controller {
     /// Responses/notifications produced by the remote worker. Consumed by the
     /// main `select!` loop and forwarded to Emacs.
     remote_result_rx: Option<Receiver<Message>>,
+    /// Request ids that originated from the remote server (e.g. workspace/applyEdit)
+    /// and were forwarded to Emacs. When Emacs responds, we discard the response
+    /// here instead of forwarding to Application, which would panic on an unknown id.
+    pending_remote_to_emacs: std::collections::HashSet<msg::RequestId>,
 }
 
 /// Unit of work queued to the remote worker thread.
@@ -106,6 +110,7 @@ impl Controller {
             _remote_manager: remote_manager,
             remote_task_tx,
             remote_result_rx,
+            pending_remote_to_emacs: std::collections::HashSet::new(),
         }
     }
 
@@ -264,7 +269,14 @@ impl Controller {
                 }
             }
             Message::Response(resp) => {
-                self.sender_for_server.send(resp.into()).unwrap();
+                if self.pending_remote_to_emacs.remove(&resp.id) {
+                    // This response is for a request that originated from the remote
+                    // server (e.g. workspace/applyEdit). The remote server already
+                    // replied to the language server without waiting, so just discard.
+                    debug!("discarding Emacs response for remote-server request id={:?}", resp.id);
+                } else {
+                    self.sender_for_server.send(resp.into()).unwrap();
+                }
             }
             Message::Notification(not) => {
                 self.sender_for_server.send(not.into()).unwrap();
@@ -380,8 +392,16 @@ impl Controller {
                                     self.sender_to_emacs.send(not.into()).unwrap();
                                 }
                                 Message::Request(req) => {
-                                    // Server-initiated requests are rare for now;
-                                    // forward verbatim.
+                                    // Server-initiated request from the remote server
+                                    // (e.g. workspace/applyEdit). Track the id so that
+                                    // Emacs' response is discarded rather than forwarded
+                                    // to Application where it would panic on an unknown id.
+                                    debug!(
+                                        "forwarding server-initiated request from remote to Emacs: \
+                                         method={} id={:?}",
+                                        req.method, req.id
+                                    );
+                                    self.pending_remote_to_emacs.insert(req.id.clone());
                                     self.sender_to_emacs.send(req.into()).unwrap();
                                 }
                             }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -90,6 +90,24 @@ impl Controller {
     }
 
     fn handle_message(&mut self, msg: Message, now: Instant) -> Result<()> {
+        // RPC-layer heartbeat from the local RpcClient. Short-circuit before
+        // we even consider remote routing or local dispatch — the whole
+        // point of the ping is to stay fast even when Application is busy,
+        // so hitting it at the Controller boundary is ideal.
+        if let Message::Request(req) = &msg {
+            if req.method == crate::remote::rpc::PING_METHOD {
+                let resp = Response {
+                    id: req.id.clone(),
+                    result: Some(serde_json::Value::Null),
+                    error: None,
+                };
+                if let Err(e) = self.sender_to_emacs.send(Message::Response(resp)) {
+                    error!("failed to reply to rpc ping: {}", e);
+                }
+                return Ok(());
+            }
+        }
+
         // If the remote worker is up and the message targets a remote path,
         // register it and hand it off to the async worker instead of the local
         // LSP pipeline.

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -47,6 +47,16 @@ enum RemoteTask {
     RouteMessage { message: Message },
     /// Query remote connection status and reply to the given request id.
     GetRemoteStatus { request_id: msg::RequestId },
+    /// Probe the remote binary locations and return a check result without deploying.
+    CheckBinary {
+        request_id: msg::RequestId,
+        connection_key: String,
+    },
+    /// User-initiated deploy: upload the local binary to the remote host.
+    DeployBinary {
+        request_id: msg::RequestId,
+        connection_key: String,
+    },
 }
 
 impl Controller {
@@ -137,6 +147,73 @@ impl Controller {
                     if let Err(e) = self.sender_to_emacs.send(Message::Response(resp)) {
                         error!("failed to reply to getRemoteInfo: {e}");
                     }
+                }
+                return Ok(());
+            }
+        }
+
+        // Remote binary check (no upload).
+        if let Message::Request(req) = &msg {
+            if req.method == lsp_ext::CheckRemoteBinary::METHOD {
+                self.register_request(req, now);
+                let connection_key = serde_json::from_value::<
+                    lsp_ext::DeployRemoteBinaryParams,
+                >(req.params.params.clone())
+                .map(|p| p.connection_key)
+                .unwrap_or_default();
+                if let Some(tx) = &self.remote_task_tx {
+                    if let Err(e) = tx.send(RemoteTask::CheckBinary {
+                        request_id: req.id.clone(),
+                        connection_key,
+                    }) {
+                        error!("remote worker channel closed: {e}");
+                    }
+                } else {
+                    let resp = Response {
+                        id: req.id.clone(),
+                        result: None,
+                        error: Some(crate::lsp::jsonrpc::Error {
+                            code: crate::lsp::jsonrpc::ErrorCode::InternalError,
+                            message: "remote manager not available".to_string(),
+                            data: None,
+                        }),
+                    };
+                    self.sender_to_emacs.send(Message::Response(resp)).ok();
+                }
+                return Ok(());
+            }
+        }
+
+        // User-initiated remote binary deploy.
+        if let Message::Request(req) = &msg {
+            if req.method == lsp_ext::DeployRemoteBinary::METHOD {
+                self.register_request(req, now);
+                let connection_key = serde_json::from_value::<
+                    lsp_ext::DeployRemoteBinaryParams,
+                >(req.params.params.clone())
+                .map(|p| p.connection_key)
+                .unwrap_or_default();
+                if let Some(tx) = &self.remote_task_tx {
+                    if let Err(e) = tx.send(RemoteTask::DeployBinary {
+                        request_id: req.id.clone(),
+                        connection_key,
+                    }) {
+                        error!("remote worker channel closed: {e}");
+                    }
+                } else {
+                    let resp = Response {
+                        id: req.id.clone(),
+                        result: Some(
+                            serde_json::to_value(lsp_ext::DeployRemoteBinaryResult {
+                                success: false,
+                                binary_path: None,
+                                message: "remote manager not available".to_string(),
+                            })
+                            .unwrap(),
+                        ),
+                        error: None,
+                    };
+                    self.sender_to_emacs.send(Message::Response(resp)).ok();
                 }
                 return Ok(());
             }
@@ -488,6 +565,59 @@ fn spawn_remote_worker(
                                 let resp = Message::Response(Response {
                                     id: request_id,
                                     result: Some(serde_json::to_value(status).unwrap()),
+                                    error: None,
+                                });
+                                if let Err(e) = result_tx.send(resp) {
+                                    warn!("remote result channel closed: {e}");
+                                }
+                            }
+                            RemoteTask::CheckBinary {
+                                request_id,
+                                connection_key,
+                            } => {
+                                let resp = match manager
+                                    .check_binary_status(&connection_key)
+                                    .await
+                                {
+                                    Ok(result) => Response {
+                                        id: request_id,
+                                        result: Some(serde_json::to_value(result).unwrap()),
+                                        error: None,
+                                    },
+                                    Err(e) => Response {
+                                        id: request_id,
+                                        result: None,
+                                        error: Some(crate::lsp::jsonrpc::Error {
+                                            code: crate::lsp::jsonrpc::ErrorCode::InternalError,
+                                            message: format!("check failed: {e}"),
+                                            data: None,
+                                        }),
+                                    },
+                                };
+                                if let Err(e) = result_tx.send(Message::Response(resp)) {
+                                    warn!("remote result channel closed: {e}");
+                                }
+                            }
+                            RemoteTask::DeployBinary {
+                                request_id,
+                                connection_key,
+                            } => {
+                                let result = manager.deploy_for_key(&connection_key).await;
+                                let reply = match result {
+                                    Ok(binary_path) => lsp_ext::DeployRemoteBinaryResult {
+                                        success: true,
+                                        binary_path: Some(binary_path),
+                                        message: "Deploy succeeded.".to_string(),
+                                    },
+                                    Err(e) => lsp_ext::DeployRemoteBinaryResult {
+                                        success: false,
+                                        binary_path: None,
+                                        message: format!("Deploy failed: {e}"),
+                                    },
+                                };
+                                let resp = Message::Response(Response {
+                                    id: request_id,
+                                    result: Some(serde_json::to_value(reply).unwrap()),
                                     error: None,
                                 });
                                 if let Err(e) = result_tx.send(resp) {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -135,7 +135,12 @@ impl Controller {
 
     fn is_remote_message(&self, message: &Message) -> bool {
         if let Some(path) = self.extract_path_from_message(message) {
-            return path.starts_with("/ssh:") || path.starts_with("/rpc:");
+            // Emacs / eglot wrap TRAMP paths in `file://` URIs. The detector
+            // understands the wrapped form, but the fast-path prefix check
+            // here also has to strip it, otherwise a real remote request
+            // silently falls through to the local LSP pipeline.
+            let probe = path.strip_prefix("file://").unwrap_or(&path);
+            return probe.starts_with("/ssh:") || probe.starts_with("/rpc:");
         }
         false
     }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -31,7 +31,7 @@ pub struct Controller {
     sender_to_emacs: Sender<Message>,
     req_queue: ReqQueue,
     processing_requests: HashMap<String, Request>,
-    remote_manager: Option<Arc<RemoteConnectionManager>>,
+    _remote_manager: Option<Arc<RemoteConnectionManager>>,
     /// Outbound channel into the remote worker thread. If `None`, remote
     /// routing is disabled and every message goes through the local path.
     remote_task_tx: Option<mpsc::UnboundedSender<RemoteTask>>,
@@ -61,8 +61,7 @@ impl Controller {
             }
             Err(e) => {
                 warn!(
-                    "Failed to initialize remote connection manager: {}. Running in local mode only.",
-                    e
+                    "Failed to initialize remote connection manager: {e}. Running in local mode only."
                 );
                 None
             }
@@ -87,7 +86,7 @@ impl Controller {
             sender_to_emacs: sender_for_emacs,
             req_queue: ReqQueue::default(),
             processing_requests: HashMap::new(),
-            remote_manager,
+            _remote_manager: remote_manager,
             remote_task_tx,
             remote_result_rx,
         }
@@ -106,7 +105,7 @@ impl Controller {
                     error: None,
                 };
                 if let Err(e) = self.sender_to_emacs.send(Message::Response(resp)) {
-                    error!("failed to reply to rpc ping: {}", e);
+                    error!("failed to reply to rpc ping: {e}");
                 }
                 return Ok(());
             }
@@ -121,7 +120,7 @@ impl Controller {
                     if let Err(e) = tx.send(RemoteTask::GetRemoteStatus {
                         request_id: req.id.clone(),
                     }) {
-                        error!("remote worker channel closed: {}", e);
+                        error!("remote worker channel closed: {e}");
                     }
                 } else {
                     // No remote manager — return a disabled status directly.
@@ -136,7 +135,7 @@ impl Controller {
                         error: None,
                     };
                     if let Err(e) = self.sender_to_emacs.send(Message::Response(resp)) {
-                        error!("failed to reply to getRemoteInfo: {}", e);
+                        error!("failed to reply to getRemoteInfo: {e}");
                     }
                 }
                 return Ok(());
@@ -152,7 +151,7 @@ impl Controller {
             }
             let tx = self.remote_task_tx.as_ref().unwrap();
             if let Err(e) = tx.send(RemoteTask::RouteMessage { message: msg }) {
-                error!("remote worker channel closed: {}", e);
+                error!("remote worker channel closed: {e}");
             }
             return Ok(());
         }
@@ -243,7 +242,7 @@ impl Controller {
                     let now = Instant::now();
                     if let Ok(msg) = msg {
                         if let Err(e) = self.handle_message(msg, now) {
-                            error!("Error handling message: {}", e);
+                            error!("Error handling message: {e}");
                         }
                     } else {
                         error!("inbox error");
@@ -303,7 +302,7 @@ impl Controller {
                             }
                         }
                         Err(err) => {
-                            warn!("remote worker result channel closed: {}", err);
+                            warn!("remote worker result channel closed: {err}");
                         }
                     }
                 }
@@ -459,7 +458,7 @@ fn spawn_remote_worker(
             {
                 Ok(rt) => rt,
                 Err(e) => {
-                    error!("failed to build tokio runtime for remote worker: {}", e);
+                    error!("failed to build tokio runtime for remote worker: {e}");
                     return;
                 }
             };
@@ -473,14 +472,14 @@ fn spawn_remote_worker(
                                 match manager.route_message(message).await {
                                     Ok(Some(response)) => {
                                         if let Err(e) = result_tx.send(response) {
-                                            warn!("remote result channel closed: {}", e);
+                                            warn!("remote result channel closed: {e}");
                                         }
                                     }
                                     Ok(None) => {
                                         debug!("remote worker: notification accepted, no response");
                                     }
                                     Err(e) => {
-                                        error!("remote routing failed: {}", e);
+                                        error!("remote routing failed: {e}");
                                     }
                                 }
                             }
@@ -492,7 +491,7 @@ fn spawn_remote_worker(
                                     error: None,
                                 });
                                 if let Err(e) = result_tx.send(resp) {
-                                    warn!("remote result channel closed: {}", e);
+                                    warn!("remote result channel closed: {e}");
                                 }
                             }
                         }

--- a/src/document.rs
+++ b/src/document.rs
@@ -308,8 +308,9 @@ impl Document {
     }
 
     fn set_language_config(&mut self, config_loader: Arc<syntax::Loader>, language: Option<&str>) {
-        let language_config =
-            config_loader.language_config_for_file_name(self.path().unwrap().as_ref(), language);
+        let language_config = self.path().and_then(|path| {
+            config_loader.language_config_for_file_name(path.as_ref(), language)
+        });
         self.language_config = language_config;
     }
 

--- a/src/fuzzy/fuzzy.rs
+++ b/src/fuzzy/fuzzy.rs
@@ -130,15 +130,10 @@ fn is_separator_at_pos(value: &str, index: usize) -> bool {
     if index > value.chars().count() {
         return false;
     }
-    if let Some(ch) = value.chars().nth(index) {
-        match ch {
-            '_' | '-' | '.' | ' ' | '/' | '\\' | '\'' | '\"' | ':' | '$' | '<' | '>' | '('
-            | ')' | '[' | ']' | '{' | '}' => true,
-            _ => false,
-        }
-    } else {
-        false
-    }
+    matches!(
+        value.chars().nth(index),
+        Some('_' | '-' | '.' | ' ' | '/' | '\\' | '\'' | '\"' | ':' | '$' | '<' | '>' | '(' | ')' | '[' | ']' | '{' | '}')
+    )
 }
 
 // Function to check if a character at a specific position is whitespace
@@ -146,14 +141,7 @@ fn is_whitespace_at_pos(value: &str, index: usize) -> bool {
     if index > value.chars().count() {
         return false;
     }
-    if let Some(ch) = value.chars().nth(index) {
-        match ch {
-            ' ' | '\t' => true,
-            _ => false,
-        }
-    } else {
-        false
-    }
+    matches!(value.chars().nth(index), Some(' ' | '\t'))
 }
 
 // Function to check if a character at a specific position in 'word' is uppercase

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -391,6 +391,12 @@ pub fn handle_exit(app: &mut Application, _params: ()) -> Result<()> {
     // Cleanup all resources
     app.cleanup_resources();
 
+    // Kill remote connections synchronously before calling process::exit().
+    // process::exit() does not run Drop implementations, so without this call
+    // the remote emacs-lsp-proxy --remote-server processes would keep running
+    // after lsp-proxy restarts.
+    crate::application::run_exit_hook();
+
     // Exit the process
     std::process::exit(exit_code);
 }

--- a/src/handlers/request.rs
+++ b/src/handlers/request.rs
@@ -274,6 +274,19 @@ pub(crate) async fn handle_completion(
 
         COMPLETION_CACHE.try_lock().unwrap().clear_cache();
 
+        debug!(
+            "completion: candidate servers = {:?}",
+            language_servers
+                .iter()
+                .map(|ls| format!(
+                    "{}(init={},feature={})",
+                    ls.name(),
+                    ls.is_initialized(),
+                    ls.with_feature(LanguageServerFeature::Completion)
+                ))
+                .collect::<Vec<_>>()
+        );
+
         let lang_servers = language_servers
             .iter()
             .filter(|ls| ls.with_feature(LanguageServerFeature::Completion));
@@ -365,14 +378,21 @@ pub(crate) async fn handle_completion(
                     let response: Option<lsp_types::CompletionResponse> =
                         serde_json::from_value(json)?;
 
-                    let items = match response {
+                    let raw_items = match response {
                         Some(lsp_types::CompletionResponse::Array(items)) => items,
                         Some(lsp_types::CompletionResponse::List(lsp_types::CompletionList {
                             is_incomplete: _is_incomplete,
                             items,
                         })) => items,
                         None => Vec::new(),
-                    }
+                    };
+                    debug!(
+                        "completion [{:?}] {} raw items from {:?}",
+                        id,
+                        raw_items.len(),
+                        language_server_name
+                    );
+                    let items = raw_items
                     .into_iter()
                     .map(|item| {
                         let mut new_item = truncate_completion_item(item);
@@ -441,6 +461,13 @@ pub(crate) async fn handle_completion(
                         }
                     }
                 }
+                debug!(
+                    "completion collected items={} prefix={:?} pretext={:?} position={:?}",
+                    items.len(),
+                    context.prefix,
+                    pretext,
+                    params.text_document_position.position
+                );
 
                 // cache items with pretext\uri\bounds_start
                 // NOTE 只有当 prefix 存在的情况下才缓存，空 prefix 的补全结果是不准确的
@@ -461,18 +488,35 @@ pub(crate) async fn handle_completion(
                     &context.prefix,
                 );
                 info!("filter elapsed {:0.2?}", now.elapsed());
+                debug!(
+                    "completion after fuzzy filter: in={} out={}",
+                    items.len(),
+                    filtered_items.len()
+                );
                 if trigger_kind == &lsp_types::CompletionTriggerKind::INVOKED || *prefix_len == 0 {
+                    debug!("completion return all filtered items: {}", filtered_items.len());
                     anyhow::Ok(filtered_items.to_owned())
                 } else {
                     let slice_length = std::cmp::min(*max_items, filtered_items.len());
                     let slice_items = &filtered_items[..slice_length];
+                    debug!(
+                        "completion return slice: max={} slice_len={}",
+                        max_items, slice_length
+                    );
                     anyhow::Ok(slice_items.to_owned())
                 }
             };
 
             let res = items_future.await;
             match res {
-                Ok(res) => Response::new_ok(req.id.clone(), res),
+                Ok(res) => {
+                    debug!(
+                        "completion final Response::new_ok items={} id={:?}",
+                        res.len(),
+                        req.id
+                    );
+                    Response::new_ok(req.id.clone(), res)
+                }
                 Err(e) => create_error_response(&req.id, e.to_string()),
             }
         };

--- a/src/handlers/request.rs
+++ b/src/handlers/request.rs
@@ -500,8 +500,7 @@ pub(crate) async fn handle_completion(
                     let slice_length = std::cmp::min(*max_items, filtered_items.len());
                     let slice_items = &filtered_items[..slice_length];
                     debug!(
-                        "completion return slice: max={} slice_len={}",
-                        max_items, slice_length
+                        "completion return slice: max={max_items} slice_len={slice_length}"
                     );
                     anyhow::Ok(slice_items.to_owned())
                 }

--- a/src/lsp_ext.rs
+++ b/src/lsp_ext.rs
@@ -352,6 +352,100 @@ impl Request for GetRemoteInfo {
     const METHOD: &'static str = "emacs/getRemoteInfo";
 }
 
+// emacs/checkRemoteBinary — probe both the global command and the deploy path
+// without uploading anything.
+#[derive(Debug)]
+pub enum CheckRemoteBinary {}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteBinaryLocationStatus {
+    /// "match" | "version_mismatch" | "missing"
+    pub status: String,
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckRemoteBinaryResult {
+    pub global: RemoteBinaryLocationStatus,
+    pub path: RemoteBinaryLocationStatus,
+    /// Set when either location has a matching binary; the value to pass to
+    /// the server launch command.
+    pub available_binary: Option<String>,
+    pub local_version: String,
+    pub deploy_path: String,
+}
+
+impl Request for CheckRemoteBinary {
+    type Params = DeployRemoteBinaryParams;
+    type Result = CheckRemoteBinaryResult;
+    const METHOD: &'static str = "emacs/checkRemoteBinary";
+}
+
+// emacs/remoteDeployNeeded — sent by the server when the remote binary is
+// missing or outdated, asking the user to trigger a manual deploy.
+#[derive(Debug)]
+pub enum RemoteDeployNeeded {}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteDeployNeededParams {
+    pub connection_key: String,
+    /// "missing" | "version_mismatch"
+    pub reason: String,
+    pub remote_version: Option<String>,
+    pub local_version: String,
+    /// The fallback deploy path that would be used if the user deploys.
+    pub deploy_path: String,
+}
+
+impl Notification for RemoteDeployNeeded {
+    type Params = RemoteDeployNeededParams;
+    const METHOD: &'static str = "emacs/remoteDeployNeeded";
+}
+
+// emacs/deployRemoteBinary — user-initiated deploy request.
+#[derive(Debug)]
+pub enum DeployRemoteBinary {}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeployRemoteBinaryParams {
+    pub connection_key: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeployRemoteBinaryResult {
+    pub success: bool,
+    /// The binary command/path now available on the remote.
+    pub binary_path: Option<String>,
+    pub message: String,
+}
+
+impl Request for DeployRemoteBinary {
+    type Params = DeployRemoteBinaryParams;
+    type Result = DeployRemoteBinaryResult;
+    const METHOD: &'static str = "emacs/deployRemoteBinary";
+}
+
+// emacs/remoteDeployProgress — progress notifications streamed during deploy.
+#[derive(Debug)]
+pub enum RemoteDeployProgress {}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteDeployProgressParams {
+    pub connection_key: String,
+    pub message: String,
+}
+
+impl Notification for RemoteDeployProgress {
+    type Params = RemoteDeployProgressParams;
+    const METHOD: &'static str = "emacs/remoteDeployProgress";
+}
+
 // emacs/forwardRequest
 #[derive(Debug)]
 pub enum ForwardRequest {}

--- a/src/lsp_ext.rs
+++ b/src/lsp_ext.rs
@@ -319,6 +319,39 @@ impl Request for RustAnalyzerExpandMacro {
     const METHOD: &'static str = "rust-analyzer/expandMacro";
 }
 
+// emacs/getRemoteInfo
+#[derive(Debug)]
+pub enum GetRemoteInfo {}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteClientInfo {
+    pub connection_key: String,
+    pub remote_type: String,
+    pub is_alive: bool,
+    /// Absolute path where the remote binary is (or should be) installed.
+    pub binary_path: String,
+    /// Version of the locally-running lsp-proxy (compile-time).
+    pub local_version: String,
+    /// Version reported by the remote binary, if reachable.
+    pub remote_version: Option<String>,
+    /// One of: "deployed", "missing", "version_mismatch", "unknown".
+    pub deploy_status: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteConnectionStatus {
+    pub enabled: bool,
+    pub clients: Vec<RemoteClientInfo>,
+}
+
+impl Request for GetRemoteInfo {
+    type Params = ();
+    type Result = RemoteConnectionStatus;
+    const METHOD: &'static str = "emacs/getRemoteInfo";
+}
+
 // emacs/forwardRequest
 #[derive(Debug)]
 pub enum ForwardRequest {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod lsp_ext;
 mod main_loop;
 mod msg;
 mod registry;
+mod remote;
 mod req_queue;
 mod syntax;
 mod thread;
@@ -65,12 +66,14 @@ fn try_main() -> Result<()> {
         return Ok(());
     }
 
-    // Check if --stdio flag is provided
-    if !args.stdio {
-        eprintln!("Error: --stdio flag is required to start the server");
+    // One of --stdio or --remote-server must be set.
+    if !args.stdio && !args.remote_server {
+        eprintln!("Error: one of --stdio or --remote-server is required to start the server");
         eprintln!("Use --help for usage information");
         std::process::exit(1);
     }
+
+    let remote_server = args.remote_server;
 
     initialize_config_file(args.config_file);
     initialize_log_file(args.log_file);
@@ -91,10 +94,15 @@ fn try_main() -> Result<()> {
     }
 
     info!(
-        "Server starting... (version: {})",
-        env!("CARGO_PKG_VERSION")
+        "Server starting... (version: {}, mode: {})",
+        env!("CARGO_PKG_VERSION"),
+        if remote_server { "remote-server" } else { "stdio" }
     );
-    with_extra_thread("LspProxy", run_server)?;
+    if remote_server {
+        with_extra_thread("LspProxy", run_remote_server)?;
+    } else {
+        with_extra_thread("LspProxy", run_server)?;
+    }
 
     Ok(())
 }
@@ -122,6 +130,15 @@ fn run_server() -> Result<()> {
     let syn_loader_config = config::default_syntax_loader();
     main_loop(connect, syn_loader_config).unwrap();
     info!("Server started successfully.");
+    io_threads.join()?;
+    Ok(())
+}
+
+fn run_remote_server() -> Result<()> {
+    let (connect, io_threads) = remote::server::envelope_stdio();
+    let syn_loader_config = config::default_syntax_loader();
+    main_loop(connect, syn_loader_config).unwrap();
+    info!("Remote server started successfully.");
     io_threads.join()?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ use log::{error, info};
 use logging::init_tracing;
 
 use crate::{
-    config::{set_copilot_server_name, set_remote_binary_path},
+    config::{initialize_remote_binary_path, set_copilot_server_name},
     connection::Connection,
     main_loop::main_loop,
 };
@@ -92,9 +92,7 @@ fn try_main() -> Result<()> {
     set_max_diagnostics_push(args.max_diagnostics_push);
     set_enable_bytecode(args.enable_bytecode);
     set_copilot_server_name(args.copilot_server_name);
-    if let Some(path) = args.remote_binary_path {
-        set_remote_binary_path(path);
-    }
+    initialize_remote_binary_path();
 
     if let Err(e) = setup_logging(args.log_level) {
         eprintln!("Failed to setup logging: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,11 @@ use config::{
 use log::{error, info};
 use logging::init_tracing;
 
-use crate::{config::set_copilot_server_name, connection::Connection, main_loop::main_loop};
+use crate::{
+    config::{set_copilot_server_name, set_remote_binary_path},
+    connection::Connection,
+    main_loop::main_loop,
+};
 
 fn setup_logging(verbosity: u64) -> Result<()> {
     // Only use tracing for all logging
@@ -88,6 +92,9 @@ fn try_main() -> Result<()> {
     set_max_diagnostics_push(args.max_diagnostics_push);
     set_enable_bytecode(args.enable_bytecode);
     set_copilot_server_name(args.copilot_server_name);
+    if let Some(path) = args.remote_binary_path {
+        set_remote_binary_path(path);
+    }
 
     if let Err(e) = setup_logging(args.log_level) {
         eprintln!("Failed to setup logging: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,16 @@ fn run_server() -> Result<()> {
     let (connect, io_threads) = Connection::stdio();
     let syn_loader_config = config::default_syntax_loader();
     main_loop(connect, syn_loader_config).unwrap();
+
+    // Clean up remote connections when the main loop exits.  This covers two
+    // cases:
+    //   1. Emacs sent `exit` notification → handle_exit already called
+    //      run_exit_hook(); calling it again here is a no-op (try_lock returns
+    //      the already-cleared state).
+    //   2. Emacs closed stdin directly (e.g. quit Emacs without lsp-proxy-restart)
+    //      → handle_exit was never called; this is the only cleanup opportunity.
+    crate::application::run_exit_hook();
+
     info!("Server started successfully.");
     io_threads.join()?;
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,7 +140,7 @@ fn with_extra_thread(
 fn run_server() -> Result<()> {
     let (connect, io_threads) = Connection::stdio();
     let syn_loader_config = config::default_syntax_loader();
-    main_loop(connect, syn_loader_config).unwrap();
+    main_loop(connect, syn_loader_config)?;
 
     // Clean up remote connections when the main loop exits.  This covers two
     // cases:
@@ -164,8 +164,7 @@ fn run_remote_server() -> Result<()> {
 
     let (connect, io_threads) = remote::server::envelope_stdio();
     let syn_loader_config = config::default_syntax_loader();
-    main_loop(connect, syn_loader_config).unwrap();
-    info!("Remote server started successfully.");
+    main_loop(connect, syn_loader_config)?;
     io_threads.join()?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,6 +200,14 @@ fn load_login_shell_env() {
         }
     };
 
+    if !output.status.success() {
+        info!(
+            "load_login_shell_env: `{shell} -l -i -c env` exited with {}, skipping env override",
+            output.status
+        );
+        return;
+    }
+
     let mut applied = 0usize;
     for line in String::from_utf8_lossy(&output.stdout).lines() {
         if let Some((key, value)) = line.split_once('=') {

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,13 @@ fn try_main() -> Result<()> {
 
     let remote_server = args.remote_server;
 
+    // Tell `default_log_file` whether we're the remote side BEFORE we touch
+    // the LOG_FILE slot — otherwise the remote binary would fall back to
+    // `~/Library/Caches/lsp-proxy/default.log` even though the user has no
+    // reason to look there.
+    config::set_remote_server_mode(remote_server);
+    config::set_log_level(args.log_level);
+
     initialize_config_file(args.config_file);
     initialize_log_file(args.log_file);
     set_max_completion_items(args.max_item_num);

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,10 +149,61 @@ fn run_server() -> Result<()> {
 }
 
 fn run_remote_server() -> Result<()> {
+    // Load the login-shell environment before anything else so that language
+    // servers (node, python, …) can be found on PATH regardless of how the
+    // binary was launched via SSH.
+    load_login_shell_env();
+
     let (connect, io_threads) = remote::server::envelope_stdio();
     let syn_loader_config = config::default_syntax_loader();
     main_loop(connect, syn_loader_config).unwrap();
     info!("Remote server started successfully.");
     io_threads.join()?;
     Ok(())
+}
+
+/// Capture the login-shell environment and apply it to the current process.
+///
+/// Runs `$SHELL -l -i -c env`, parses the output as `KEY=VALUE` lines, and
+/// calls `std::env::set_var` for every variable except `SHLVL` (which would
+/// confuse nested-shell detection).  Errors are logged but never fatal —
+/// if the capture fails the server still starts with its inherited env.
+fn load_login_shell_env() {
+    use std::process::{Command, Stdio};
+
+    let shell = match std::env::var("SHELL") {
+        Ok(s) if !s.is_empty() => s,
+        _ => {
+            info!("load_login_shell_env: $SHELL not set, skipping");
+            return;
+        }
+    };
+
+    let output = Command::new(&shell)
+        .args(["-l", "-i", "-c", "env"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null()) // discard interactive-mode noise (greeting, PS1, etc.)
+        .output();
+
+    let output = match output {
+        Ok(o) => o,
+        Err(e) => {
+            info!("load_login_shell_env: failed to run `{shell} -l -i -c env`: {e}");
+            return;
+        }
+    };
+
+    let mut applied = 0usize;
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        if let Some((key, value)) = line.split_once('=') {
+            if key == "SHLVL" {
+                continue;
+            }
+            // SAFETY: single-threaded at this point; no other threads have
+            // been spawned yet so there is no risk of concurrent reads.
+            unsafe { std::env::set_var(key, value) };
+            applied += 1;
+        }
+    }
+    info!("load_login_shell_env: applied {applied} variables from `{shell} -l -i -c env`");
 }

--- a/src/remote/deploy.rs
+++ b/src/remote/deploy.rs
@@ -2,13 +2,13 @@
 //! exists on the remote host, and deploy it on demand.
 //!
 //! The check runs `<remote_path> --version` over the SSH ControlMaster.
-//! Deployment (upload + chmod) is always user-initiated — this module never
-//! auto-deploys; callers that need deployment should invoke
-//! `deploy_with_progress` explicitly.
+//! Deployment downloads the correct release archive from GitHub based on the
+//! remote platform — the local binary is never uploaded directly, avoiding
+//! cross-architecture issues.  Deployment is always user-initiated; callers
+//! that need it should invoke `deploy_with_progress` explicitly.
 
 use anyhow::{anyhow, Context, Result};
 use log::{debug, info, warn};
-use std::path::{Path, PathBuf};
 
 use super::ssh::SshConnection;
 
@@ -72,35 +72,97 @@ pub async fn check_remote_binary(
     }
 }
 
-/// Upload the local running binary to `remote_path`. Creates the parent
-/// directory and chmods +x afterwards.
-pub async fn deploy_binary(
+/// Detect the remote host's OS and CPU architecture.
+///
+/// Returns `(os, arch)` where `os` is lowercase `"linux"` or `"darwin"` and
+/// `arch` is `"x86_64"` or `"aarch64"`.
+async fn detect_remote_platform(conn: &SshConnection) -> Result<(String, String)> {
+    let output = conn
+        .run_command("uname -sm")
+        .await
+        .context("failed to detect remote platform")?;
+    let parts: Vec<&str> = output.trim().splitn(2, ' ').collect();
+    if parts.len() != 2 {
+        anyhow::bail!("unexpected `uname -sm` output: {:?}", output.trim());
+    }
+    let os = parts[0].to_lowercase();
+    let arch = parts[1].to_lowercase();
+    Ok((os, arch))
+}
+
+/// Map `(os, arch)` to the GitHub release archive filename.
+///
+/// Archive naming from CI:
+///   lsp-proxy-linux-x86_64.tar.gz
+///   lsp-proxy-linux-arm64.tar.gz
+///   lsp-proxy-macos-x86_64.tar.gz
+///   lsp-proxy-macos-arm64.tar.gz
+fn release_archive_name(os: &str, arch: &str) -> Result<String> {
+    let os_label = match os {
+        "linux" => "linux",
+        "darwin" => "macos",
+        other => anyhow::bail!("unsupported remote OS: {other}"),
+    };
+    let arch_label = match arch {
+        "x86_64" => "x86_64",
+        "aarch64" | "arm64" => "arm64",
+        other => anyhow::bail!("unsupported remote architecture: {other}"),
+    };
+    Ok(format!("lsp-proxy-{os_label}-{arch_label}.tar.gz"))
+}
+
+/// Download the correct GitHub release binary onto the remote host.
+///
+/// Uses `curl` when available, falls back to `wget`.  The archive is
+/// downloaded to a temporary directory, the binary extracted, moved to
+/// `remote_path`, and the temp directory cleaned up.
+async fn download_release_on_remote(
     conn: &SshConnection,
-    local_path: &Path,
     remote_path: &str,
+    archive_name: &str,
+    on_progress: &(impl Fn(String) + Send + Sync),
 ) -> Result<()> {
+    let url = format!(
+        "https://github.com/jadestrong/lsp-proxy/releases/download/v{EXPECTED_VERSION}/{archive_name}"
+    );
     let parent = remote_parent_dir(remote_path);
-    let mkdir = format!("mkdir -p {}", shell_escape(&parent));
-    debug!("preparing remote dir: {mkdir}");
-    conn.run_command(&mkdir)
+
+    on_progress(format!("Creating remote directory {parent}..."));
+    conn.run_command(&format!("mkdir -p {}", shell_escape(&parent)))
         .await
         .context("failed to create remote install directory")?;
 
-    info!(
-        "uploading {} -> {} (v{})",
-        local_path.display(),
-        remote_path,
-        EXPECTED_VERSION
+    on_progress(format!("Downloading {url}..."));
+    // Try curl first, fall back to wget.  A temp dir holds the archive so the
+    // final path is only written once the download and extraction succeed.
+    let download_cmd = format!(
+        "TMPDIR=$(mktemp -d) && \
+         {{ command -v curl >/dev/null 2>&1 && \
+            curl -fSL {url} -o \"$TMPDIR/archive.tar.gz\" || \
+            wget -q -O \"$TMPDIR/archive.tar.gz\" {url}; }} && \
+         tar -xzf \"$TMPDIR/archive.tar.gz\" -C \"$TMPDIR\" emacs-lsp-proxy && \
+         mv \"$TMPDIR/emacs-lsp-proxy\" {dest} && \
+         chmod +x {dest}; \
+         STATUS=$?; rm -rf \"$TMPDIR\"; exit $STATUS",
+        url = shell_escape(&url),
+        dest = shell_escape(remote_path),
     );
-    conn.scp_upload(local_path, remote_path)
-        .await
-        .context("scp upload failed")?;
 
-    let chmod = format!("chmod +x {}", shell_escape(remote_path));
-    conn.run_command(&chmod)
+    let output = conn
+        .run_command_with_status(&download_cmd)
         .await
-        .context("failed to chmod remote binary")?;
+        .context("download command failed to launch")?;
 
+    if !output.is_success() {
+        anyhow::bail!(
+            "download failed (exit {:?}):\n{}",
+            output.exit_code,
+            output.stderr.trim()
+        );
+    }
+
+    on_progress("Download and extraction complete.".to_string());
+    info!("installed {remote_path} v{EXPECTED_VERSION} from {archive_name}");
     Ok(())
 }
 
@@ -144,10 +206,13 @@ pub async fn check_binary_available(
     }
 }
 
-/// Deploy the local binary to `remote_path`, reporting progress via `on_progress`.
+/// Deploy the correct release binary to `remote_path`, reporting progress via
+/// `on_progress`.
 ///
-/// Checks the global command and `remote_path` first; if either is already
-/// up-to-date the upload is skipped.  Returns the command/path to use.
+/// Checks the global command and `remote_path` first; if either already has a
+/// matching version no download is performed.  When a download is needed the
+/// remote platform is detected automatically and the appropriate release
+/// archive is fetched from GitHub.  Returns the command/path to use.
 pub async fn deploy_with_progress(
     conn: &SshConnection,
     remote_path: &str,
@@ -159,7 +224,7 @@ pub async fn deploy_with_progress(
     match check_remote_binary(conn, "emacs-lsp-proxy").await? {
         RemoteBinaryStatus::VersionMatch => {
             on_progress(format!(
-                "Global emacs-lsp-proxy v{EXPECTED_VERSION} found — no upload needed."
+                "Global emacs-lsp-proxy v{EXPECTED_VERSION} found — no download needed."
             ));
             return Ok("emacs-lsp-proxy".to_string());
         }
@@ -177,45 +242,39 @@ pub async fn deploy_with_progress(
     match check_remote_binary(conn, remote_path).await? {
         RemoteBinaryStatus::VersionMatch => {
             on_progress(format!(
-                "{remote_path} is already v{EXPECTED_VERSION} — no upload needed."
+                "{remote_path} is already v{EXPECTED_VERSION} — no download needed."
             ));
             return Ok(remote_path.to_string());
         }
         RemoteBinaryStatus::Missing => {
-            on_progress(format!("{remote_path} not found, uploading..."));
+            on_progress(format!("{remote_path} not found, downloading..."));
         }
         RemoteBinaryStatus::VersionMismatch { remote } => {
             on_progress(format!(
-                "{remote_path} is v{remote}, re-uploading v{EXPECTED_VERSION}..."
+                "{remote_path} is v{remote}, downloading v{EXPECTED_VERSION}..."
             ));
         }
     }
 
-    let local_path = current_binary_path().context("locating local lsp-proxy binary")?;
-    on_progress(format!(
-        "Uploading {} ({} bytes)...",
-        local_path.display(),
-        std::fs::metadata(&local_path)
-            .map(|m| m.len().to_string())
-            .unwrap_or_else(|_| "?".to_string()),
-    ));
-    deploy_binary(conn, &local_path, remote_path).await?;
+    on_progress("Detecting remote platform...".to_string());
+    let (os, arch) = detect_remote_platform(conn).await?;
+    on_progress(format!("Remote platform: {os} / {arch}"));
 
-    on_progress("Upload complete, verifying...".to_string());
+    let archive = release_archive_name(&os, &arch)?;
+    on_progress(format!("Release archive: {archive}"));
+
+    download_release_on_remote(conn, remote_path, &archive, on_progress).await?;
+
+    on_progress("Verifying installed binary...".to_string());
     match check_remote_binary(conn, remote_path).await? {
         RemoteBinaryStatus::VersionMatch => {
-            on_progress(format!("Deploy successful: {remote_path} v{EXPECTED_VERSION}."));
+            on_progress(format!("✓ Deploy successful: {remote_path} v{EXPECTED_VERSION}."));
             Ok(remote_path.to_string())
         }
         other => Err(anyhow!(
             "remote binary still not healthy after deploy: {other:?}"
         )),
     }
-}
-
-/// Best-guess path to the currently-running executable, for `scp`-ing.
-fn current_binary_path() -> Result<PathBuf> {
-    std::env::current_exe().context("std::env::current_exe() failed")
 }
 
 /// Parent directory component of a remote path string. We do string-level

--- a/src/remote/deploy.rs
+++ b/src/remote/deploy.rs
@@ -1,10 +1,10 @@
-//! Auto-deploy: make sure a compatible `emacs-lsp-proxy` binary lives at the
-//! expected path on the remote host before we try to start it.
+//! Remote binary management: check whether a compatible `emacs-lsp-proxy`
+//! exists on the remote host, and deploy it on demand.
 //!
-//! The check runs `<remote_path> --version` over the SSH ControlMaster. If the
-//! binary is missing or reports a different version than the local one, we
-//! upload the currently-running executable via `scp` (reusing the same socket,
-//! so it's a single round trip).
+//! The check runs `<remote_path> --version` over the SSH ControlMaster.
+//! Deployment (upload + chmod) is always user-initiated — this module never
+//! auto-deploys; callers that need deployment should invoke
+//! `deploy_with_progress` explicitly.
 
 use anyhow::{anyhow, Context, Result};
 use log::{debug, info, warn};
@@ -104,34 +104,111 @@ pub async fn deploy_binary(
     Ok(())
 }
 
-/// Make sure the remote binary is present at the right version, deploying
-/// the local binary if needed. Returns the final path the caller should use
-/// when launching the remote server.
-pub async fn ensure_remote_binary(conn: &SshConnection, remote_path: &str) -> Result<()> {
-    let status = check_remote_binary(conn, remote_path).await?;
-    match &status {
+/// Check whether a compatible binary is already available on the remote host.
+///
+/// Priority: global `emacs-lsp-proxy` in PATH first, then `remote_path`.
+/// Returns the command/path to use, or `Err` if neither location has a
+/// matching binary — the caller should then ask the user to run a deploy.
+pub async fn check_binary_available(
+    conn: &SshConnection,
+    remote_path: &str,
+) -> Result<String> {
+    match check_remote_binary(conn, "emacs-lsp-proxy").await? {
         RemoteBinaryStatus::VersionMatch => {
-            debug!("remote binary at {remote_path} is up to date");
-            return Ok(());
+            info!("using global emacs-lsp-proxy on remote (v{EXPECTED_VERSION})");
+            return Ok("emacs-lsp-proxy".to_string());
         }
         RemoteBinaryStatus::Missing => {
-            info!("remote binary {remote_path} missing, deploying");
+            debug!("emacs-lsp-proxy not found in remote PATH, checking {remote_path}");
         }
         RemoteBinaryStatus::VersionMismatch { remote } => {
             info!(
-                "remote binary {remote_path} version mismatch ({remote} vs local {EXPECTED_VERSION}), redeploying"
+                "global emacs-lsp-proxy on remote is v{remote} (need v{EXPECTED_VERSION}), \
+                 checking {remote_path}"
             );
         }
     }
 
+    match check_remote_binary(conn, remote_path).await? {
+        RemoteBinaryStatus::VersionMatch => {
+            debug!("remote binary at {remote_path} is up to date");
+            Ok(remote_path.to_string())
+        }
+        RemoteBinaryStatus::Missing => Err(anyhow!(
+            "emacs-lsp-proxy not found (checked global PATH and {remote_path})"
+        )),
+        RemoteBinaryStatus::VersionMismatch { remote } => Err(anyhow!(
+            "emacs-lsp-proxy version mismatch: remote has v{remote}, need v{EXPECTED_VERSION} \
+             (checked global PATH and {remote_path})"
+        )),
+    }
+}
+
+/// Deploy the local binary to `remote_path`, reporting progress via `on_progress`.
+///
+/// Checks the global command and `remote_path` first; if either is already
+/// up-to-date the upload is skipped.  Returns the command/path to use.
+pub async fn deploy_with_progress(
+    conn: &SshConnection,
+    remote_path: &str,
+    on_progress: &(impl Fn(String) + Send + Sync),
+) -> Result<String> {
+    on_progress(format!(
+        "Checking global emacs-lsp-proxy on remote (need v{EXPECTED_VERSION})..."
+    ));
+    match check_remote_binary(conn, "emacs-lsp-proxy").await? {
+        RemoteBinaryStatus::VersionMatch => {
+            on_progress(format!(
+                "Global emacs-lsp-proxy v{EXPECTED_VERSION} found — no upload needed."
+            ));
+            return Ok("emacs-lsp-proxy".to_string());
+        }
+        RemoteBinaryStatus::Missing => {
+            on_progress("Global emacs-lsp-proxy not found in remote PATH.".to_string());
+        }
+        RemoteBinaryStatus::VersionMismatch { remote } => {
+            on_progress(format!(
+                "Global emacs-lsp-proxy is v{remote}, need v{EXPECTED_VERSION}."
+            ));
+        }
+    }
+
+    on_progress(format!("Checking {remote_path}..."));
+    match check_remote_binary(conn, remote_path).await? {
+        RemoteBinaryStatus::VersionMatch => {
+            on_progress(format!(
+                "{remote_path} is already v{EXPECTED_VERSION} — no upload needed."
+            ));
+            return Ok(remote_path.to_string());
+        }
+        RemoteBinaryStatus::Missing => {
+            on_progress(format!("{remote_path} not found, uploading..."));
+        }
+        RemoteBinaryStatus::VersionMismatch { remote } => {
+            on_progress(format!(
+                "{remote_path} is v{remote}, re-uploading v{EXPECTED_VERSION}..."
+            ));
+        }
+    }
+
     let local_path = current_binary_path().context("locating local lsp-proxy binary")?;
+    on_progress(format!(
+        "Uploading {} ({} bytes)...",
+        local_path.display(),
+        std::fs::metadata(&local_path)
+            .map(|m| m.len().to_string())
+            .unwrap_or_else(|_| "?".to_string()),
+    ));
     deploy_binary(conn, &local_path, remote_path).await?;
 
-    // Post-deploy sanity: the new binary should now report the expected version.
+    on_progress("Upload complete, verifying...".to_string());
     match check_remote_binary(conn, remote_path).await? {
-        RemoteBinaryStatus::VersionMatch => Ok(()),
+        RemoteBinaryStatus::VersionMatch => {
+            on_progress(format!("Deploy successful: {remote_path} v{EXPECTED_VERSION}."));
+            Ok(remote_path.to_string())
+        }
         other => Err(anyhow!(
-            "after deploy, remote binary still not healthy: {other:?}"
+            "remote binary still not healthy after deploy: {other:?}"
         )),
     }
 }

--- a/src/remote/deploy.rs
+++ b/src/remote/deploy.rs
@@ -38,7 +38,10 @@ pub async fn check_remote_binary(
     remote_path: &str,
 ) -> Result<RemoteBinaryStatus> {
     // Wrap in a shell so `~` expands on the remote side.
-    let command = format!("sh -c '{} --version 2>/dev/null'", shell_escape(remote_path));
+    let command = format!(
+        "sh -c '{} --version 2>/dev/null'",
+        shell_escape(remote_path)
+    );
     let output = conn
         .run_command_with_status(&command)
         .await
@@ -78,7 +81,7 @@ pub async fn deploy_binary(
 ) -> Result<()> {
     let parent = remote_parent_dir(remote_path);
     let mkdir = format!("mkdir -p {}", shell_escape(&parent));
-    debug!("preparing remote dir: {}", mkdir);
+    debug!("preparing remote dir: {mkdir}");
     conn.run_command(&mkdir)
         .await
         .context("failed to create remote install directory")?;
@@ -108,16 +111,15 @@ pub async fn ensure_remote_binary(conn: &SshConnection, remote_path: &str) -> Re
     let status = check_remote_binary(conn, remote_path).await?;
     match &status {
         RemoteBinaryStatus::VersionMatch => {
-            debug!("remote binary at {} is up to date", remote_path);
+            debug!("remote binary at {remote_path} is up to date");
             return Ok(());
         }
         RemoteBinaryStatus::Missing => {
-            info!("remote binary {} missing, deploying", remote_path);
+            info!("remote binary {remote_path} missing, deploying");
         }
         RemoteBinaryStatus::VersionMismatch { remote } => {
             info!(
-                "remote binary {} version mismatch ({} vs local {}), redeploying",
-                remote_path, remote, EXPECTED_VERSION
+                "remote binary {remote_path} version mismatch ({remote} vs local {EXPECTED_VERSION}), redeploying"
             );
         }
     }
@@ -129,8 +131,7 @@ pub async fn ensure_remote_binary(conn: &SshConnection, remote_path: &str) -> Re
     match check_remote_binary(conn, remote_path).await? {
         RemoteBinaryStatus::VersionMatch => Ok(()),
         other => Err(anyhow!(
-            "after deploy, remote binary still not healthy: {:?}",
-            other
+            "after deploy, remote binary still not healthy: {other:?}"
         )),
     }
 }
@@ -172,7 +173,7 @@ fn shell_escape(s: &str) -> String {
     } else {
         // Wrap in single quotes and escape any internal quotes.
         let escaped = s.replace('\'', r#"'\''"#);
-        format!("'{}'", escaped)
+        format!("'{escaped}'")
     }
 }
 
@@ -190,10 +191,7 @@ mod tests {
             parse_version_output("emacs-lsp-proxy 0.7.2\n"),
             Some("0.7.2")
         );
-        assert_eq!(
-            parse_version_output("emacs-lsp-proxy 0.8.0"),
-            Some("0.8.0")
-        );
+        assert_eq!(parse_version_output("emacs-lsp-proxy 0.8.0"), Some("0.8.0"));
         // Subsequent lines are ignored.
         assert_eq!(
             parse_version_output("emacs-lsp-proxy 1.0.0\nextra info\n"),
@@ -218,8 +216,14 @@ mod tests {
 
     #[test]
     fn shell_escape_safe_strings_untouched() {
-        assert_eq!(shell_escape("~/.local/bin/emacs-lsp-proxy"), "~/.local/bin/emacs-lsp-proxy");
-        assert_eq!(shell_escape("/usr/local/bin/foo.sh"), "/usr/local/bin/foo.sh");
+        assert_eq!(
+            shell_escape("~/.local/bin/emacs-lsp-proxy"),
+            "~/.local/bin/emacs-lsp-proxy"
+        );
+        assert_eq!(
+            shell_escape("/usr/local/bin/foo.sh"),
+            "/usr/local/bin/foo.sh"
+        );
     }
 
     #[test]
@@ -227,10 +231,7 @@ mod tests {
         // Space must force quoting.
         assert_eq!(shell_escape("hello world"), "'hello world'");
         // Embedded single quote must be escaped.
-        assert_eq!(
-            shell_escape("it's"),
-            r#"'it'\''s'"#
-        );
+        assert_eq!(shell_escape("it's"), r#"'it'\''s'"#);
         // Shell metacharacters must force quoting.
         assert_eq!(shell_escape("foo;rm -rf"), "'foo;rm -rf'");
     }
@@ -241,9 +242,7 @@ mod tests {
         assert_eq!(RemoteBinaryStatus::Missing, RemoteBinaryStatus::Missing);
         assert_ne!(
             RemoteBinaryStatus::VersionMatch,
-            RemoteBinaryStatus::VersionMismatch {
-                remote: "x".into()
-            }
+            RemoteBinaryStatus::VersionMismatch { remote: "x".into() }
         );
     }
 }

--- a/src/remote/deploy.rs
+++ b/src/remote/deploy.rs
@@ -1,0 +1,248 @@
+//! Auto-deploy: make sure a compatible `emacs-lsp-proxy` binary lives at the
+//! expected path on the remote host before we try to start it.
+//!
+//! The check runs `<remote_path> --version` over the SSH ControlMaster. If the
+//! binary is missing or reports a different version than the local one, we
+//! upload the currently-running executable via `scp` (reusing the same socket,
+//! so it's a single round trip).
+
+use anyhow::{anyhow, Context, Result};
+use log::{debug, info, warn};
+use std::path::{Path, PathBuf};
+
+use super::ssh::SshConnection;
+
+/// Default location we install the remote binary. Chosen so it shows up on
+/// the user's PATH on typical Linux/macOS setups without needing sudo.
+pub const DEFAULT_REMOTE_BINARY_PATH: &str = "~/.local/bin/emacs-lsp-proxy";
+
+/// Version expected on the remote side — baked in at compile time so that
+/// upgrading the local crate naturally triggers a redeploy.
+pub const EXPECTED_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Outcome of probing the remote binary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteBinaryStatus {
+    /// Binary isn't present (or isn't executable).
+    Missing,
+    /// Present and its reported version matches [`EXPECTED_VERSION`].
+    VersionMatch,
+    /// Present but reports a different version; redeploy recommended.
+    VersionMismatch { remote: String },
+}
+
+/// Probe the remote host for the binary at `remote_path`.
+pub async fn check_remote_binary(
+    conn: &SshConnection,
+    remote_path: &str,
+) -> Result<RemoteBinaryStatus> {
+    // Wrap in a shell so `~` expands on the remote side.
+    let command = format!("sh -c '{} --version 2>/dev/null'", shell_escape(remote_path));
+    let output = conn
+        .run_command_with_status(&command)
+        .await
+        .context("probing remote binary version")?;
+
+    if !output.is_success() {
+        debug!(
+            "remote `{}` probe exited non-zero (code={:?}, stderr={})",
+            remote_path,
+            output.exit_code,
+            output.stderr.trim()
+        );
+        return Ok(RemoteBinaryStatus::Missing);
+    }
+
+    match parse_version_output(&output.stdout) {
+        Some(v) if v == EXPECTED_VERSION => Ok(RemoteBinaryStatus::VersionMatch),
+        Some(v) => Ok(RemoteBinaryStatus::VersionMismatch {
+            remote: v.to_string(),
+        }),
+        None => {
+            warn!(
+                "remote `{}` produced unparsable version output: {:?}",
+                remote_path, output.stdout
+            );
+            Ok(RemoteBinaryStatus::Missing)
+        }
+    }
+}
+
+/// Upload the local running binary to `remote_path`. Creates the parent
+/// directory and chmods +x afterwards.
+pub async fn deploy_binary(
+    conn: &SshConnection,
+    local_path: &Path,
+    remote_path: &str,
+) -> Result<()> {
+    let parent = remote_parent_dir(remote_path);
+    let mkdir = format!("mkdir -p {}", shell_escape(&parent));
+    debug!("preparing remote dir: {}", mkdir);
+    conn.run_command(&mkdir)
+        .await
+        .context("failed to create remote install directory")?;
+
+    info!(
+        "uploading {} -> {} (v{})",
+        local_path.display(),
+        remote_path,
+        EXPECTED_VERSION
+    );
+    conn.scp_upload(local_path, remote_path)
+        .await
+        .context("scp upload failed")?;
+
+    let chmod = format!("chmod +x {}", shell_escape(remote_path));
+    conn.run_command(&chmod)
+        .await
+        .context("failed to chmod remote binary")?;
+
+    Ok(())
+}
+
+/// Make sure the remote binary is present at the right version, deploying
+/// the local binary if needed. Returns the final path the caller should use
+/// when launching the remote server.
+pub async fn ensure_remote_binary(conn: &SshConnection, remote_path: &str) -> Result<()> {
+    let status = check_remote_binary(conn, remote_path).await?;
+    match &status {
+        RemoteBinaryStatus::VersionMatch => {
+            debug!("remote binary at {} is up to date", remote_path);
+            return Ok(());
+        }
+        RemoteBinaryStatus::Missing => {
+            info!("remote binary {} missing, deploying", remote_path);
+        }
+        RemoteBinaryStatus::VersionMismatch { remote } => {
+            info!(
+                "remote binary {} version mismatch ({} vs local {}), redeploying",
+                remote_path, remote, EXPECTED_VERSION
+            );
+        }
+    }
+
+    let local_path = current_binary_path().context("locating local lsp-proxy binary")?;
+    deploy_binary(conn, &local_path, remote_path).await?;
+
+    // Post-deploy sanity: the new binary should now report the expected version.
+    match check_remote_binary(conn, remote_path).await? {
+        RemoteBinaryStatus::VersionMatch => Ok(()),
+        other => Err(anyhow!(
+            "after deploy, remote binary still not healthy: {:?}",
+            other
+        )),
+    }
+}
+
+/// Best-guess path to the currently-running executable, for `scp`-ing.
+fn current_binary_path() -> Result<PathBuf> {
+    std::env::current_exe().context("std::env::current_exe() failed")
+}
+
+/// Parent directory component of a remote path string. We do string-level
+/// splitting rather than `Path` because the remote may not use the same path
+/// conventions (e.g. the caller passes `~/.local/bin/...`).
+fn remote_parent_dir(remote_path: &str) -> String {
+    match remote_path.rfind('/') {
+        Some(0) => "/".to_string(),
+        Some(idx) => remote_path[..idx].to_string(),
+        None => ".".to_string(),
+    }
+}
+
+/// Parse the output of `emacs-lsp-proxy --version`, which is of the form
+/// `emacs-lsp-proxy 0.7.2`. Returns just the version token.
+pub fn parse_version_output(output: &str) -> Option<&str> {
+    output
+        .lines()
+        .next()?
+        .trim()
+        .rsplit_once(' ')
+        .map(|(_, v)| v)
+}
+
+/// Very small shell escape for use inside single-quoted `sh -c '…'` wrappers
+/// and path-only args. This is intentionally conservative: we only accept
+/// characters that are safe without any quoting, so anything exotic just
+/// surfaces a clearer error than silent expansion.
+fn shell_escape(s: &str) -> String {
+    if s.chars().all(is_shell_safe) {
+        s.to_string()
+    } else {
+        // Wrap in single quotes and escape any internal quotes.
+        let escaped = s.replace('\'', r#"'\''"#);
+        format!("'{}'", escaped)
+    }
+}
+
+fn is_shell_safe(c: char) -> bool {
+    matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '/' | '.' | '_' | '-' | '~')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_version_ok() {
+        assert_eq!(
+            parse_version_output("emacs-lsp-proxy 0.7.2\n"),
+            Some("0.7.2")
+        );
+        assert_eq!(
+            parse_version_output("emacs-lsp-proxy 0.8.0"),
+            Some("0.8.0")
+        );
+        // Subsequent lines are ignored.
+        assert_eq!(
+            parse_version_output("emacs-lsp-proxy 1.0.0\nextra info\n"),
+            Some("1.0.0")
+        );
+    }
+
+    #[test]
+    fn parse_version_handles_garbage() {
+        // Single token with no space can't be parsed as "<name> <version>".
+        assert_eq!(parse_version_output("nonsense"), None);
+        assert_eq!(parse_version_output(""), None);
+    }
+
+    #[test]
+    fn remote_parent_dir_cases() {
+        assert_eq!(remote_parent_dir("~/.local/bin/foo"), "~/.local/bin");
+        assert_eq!(remote_parent_dir("/usr/local/bin/foo"), "/usr/local/bin");
+        assert_eq!(remote_parent_dir("/foo"), "/");
+        assert_eq!(remote_parent_dir("plain"), ".");
+    }
+
+    #[test]
+    fn shell_escape_safe_strings_untouched() {
+        assert_eq!(shell_escape("~/.local/bin/emacs-lsp-proxy"), "~/.local/bin/emacs-lsp-proxy");
+        assert_eq!(shell_escape("/usr/local/bin/foo.sh"), "/usr/local/bin/foo.sh");
+    }
+
+    #[test]
+    fn shell_escape_quotes_dangerous_strings() {
+        // Space must force quoting.
+        assert_eq!(shell_escape("hello world"), "'hello world'");
+        // Embedded single quote must be escaped.
+        assert_eq!(
+            shell_escape("it's"),
+            r#"'it'\''s'"#
+        );
+        // Shell metacharacters must force quoting.
+        assert_eq!(shell_escape("foo;rm -rf"), "'foo;rm -rf'");
+    }
+
+    #[test]
+    fn status_enum_equality() {
+        // Sanity-check the derived PartialEq so later tests can use assert_eq!.
+        assert_eq!(RemoteBinaryStatus::Missing, RemoteBinaryStatus::Missing);
+        assert_ne!(
+            RemoteBinaryStatus::VersionMatch,
+            RemoteBinaryStatus::VersionMismatch {
+                remote: "x".into()
+            }
+        );
+    }
+}

--- a/src/remote/deploy.rs
+++ b/src/remote/deploy.rs
@@ -122,46 +122,103 @@ async fn download_release_on_remote(
     archive_name: &str,
     on_progress: &(impl Fn(String) + Send + Sync),
 ) -> Result<()> {
+    // All commands that need POSIX syntax are wrapped in `sh -c '...'` so
+    // they run under a POSIX shell regardless of the remote user's login
+    // shell (fish, nushell, etc. do not support POSIX variable syntax).
     let url = format!(
         "https://github.com/jadestrong/lsp-proxy/releases/download/v{EXPECTED_VERSION}/{archive_name}"
     );
     let parent = remote_parent_dir(remote_path);
 
-    on_progress(format!("Creating remote directory {parent}..."));
-    conn.run_command(&format!("mkdir -p {}", shell_escape(&parent)))
+    // 1. Create a temp directory and capture its path.
+    on_progress("Preparing temporary directory...".to_string());
+    let tmpdir = conn
+        .run_command("sh -c 'mktemp -d'")
         .await
-        .context("failed to create remote install directory")?;
+        .context("failed to create remote temp directory")?
+        .trim()
+        .to_string();
+    if tmpdir.is_empty() {
+        anyhow::bail!("mktemp -d returned an empty path");
+    }
+    let archive  = format!("{tmpdir}/archive.tar.gz");
+    let extracted = format!("{tmpdir}/emacs-lsp-proxy");
+    let cleanup  = format!("rm -rf {}", shell_escape(&tmpdir));
 
+    // 2. Ensure the destination directory exists.
+    on_progress(format!("Creating remote directory {parent}..."));
+    if let Err(e) = conn
+        .run_command(&format!("mkdir -p {}", shell_escape(&parent)))
+        .await
+    {
+        conn.run_command(&cleanup).await.ok();
+        return Err(e).context("failed to create remote install directory");
+    }
+
+    // 3. Download the archive (curl preferred, wget as fallback).
     on_progress(format!("Downloading {url}..."));
-    // Try curl first, fall back to wget.  A temp dir holds the archive so the
-    // final path is only written once the download and extraction succeed.
-    let download_cmd = format!(
-        "TMPDIR=$(mktemp -d) && \
-         {{ command -v curl >/dev/null 2>&1 && \
-            curl -fSL {url} -o \"$TMPDIR/archive.tar.gz\" || \
-            wget -q -O \"$TMPDIR/archive.tar.gz\" {url}; }} && \
-         tar -xzf \"$TMPDIR/archive.tar.gz\" -C \"$TMPDIR\" emacs-lsp-proxy && \
-         mv \"$TMPDIR/emacs-lsp-proxy\" {dest} && \
-         chmod +x {dest}; \
-         STATUS=$?; rm -rf \"$TMPDIR\"; exit $STATUS",
-        url = shell_escape(&url),
-        dest = shell_escape(remote_path),
+    let dl_script = format!(
+        "command -v curl >/dev/null 2>&1 && \
+         curl -fSL {url} -o {archive} || \
+         wget -q -O {archive} {url}",
+        url     = shell_escape(&url),
+        archive = shell_escape(&archive),
     );
-
     let output = conn
-        .run_command_with_status(&download_cmd)
+        .run_command_with_status(&format!("sh -c {}", shell_escape(&dl_script)))
         .await
         .context("download command failed to launch")?;
-
     if !output.is_success() {
+        conn.run_command(&cleanup).await.ok();
         anyhow::bail!(
             "download failed (exit {:?}):\n{}",
             output.exit_code,
             output.stderr.trim()
         );
     }
+    on_progress("Download complete.".to_string());
 
-    on_progress("Download and extraction complete.".to_string());
+    // 4. Extract the binary from the archive.
+    on_progress("Extracting binary from archive...".to_string());
+    let output = conn
+        .run_command_with_status(&format!(
+            "tar -xzf {} -C {} emacs-lsp-proxy",
+            shell_escape(&archive),
+            shell_escape(&tmpdir),
+        ))
+        .await
+        .context("extraction command failed to launch")?;
+    if !output.is_success() {
+        conn.run_command(&cleanup).await.ok();
+        anyhow::bail!(
+            "extraction failed (exit {:?}):\n{}",
+            output.exit_code,
+            output.stderr.trim()
+        );
+    }
+    on_progress("Extraction complete.".to_string());
+
+    // 5. Move the binary into place and make it executable.
+    on_progress(format!("Installing to {remote_path}..."));
+    let install_script = format!(
+        "mv {src} {dest} && chmod +x {dest}",
+        src  = shell_escape(&extracted),
+        dest = shell_escape(remote_path),
+    );
+    let output = conn
+        .run_command_with_status(&format!("sh -c {}", shell_escape(&install_script)))
+        .await
+        .context("install command failed to launch")?;
+    conn.run_command(&cleanup).await.ok();
+    if !output.is_success() {
+        anyhow::bail!(
+            "install failed (exit {:?}):\n{}",
+            output.exit_code,
+            output.stderr.trim()
+        );
+    }
+
+    on_progress(format!("Installed {remote_path} v{EXPECTED_VERSION}."));
     info!("installed {remote_path} v{EXPECTED_VERSION} from {archive_name}");
     Ok(())
 }

--- a/src/remote/deploy.rs
+++ b/src/remote/deploy.rs
@@ -12,9 +12,10 @@ use std::path::{Path, PathBuf};
 
 use super::ssh::SshConnection;
 
-/// Default location we install the remote binary. Chosen so it shows up on
-/// the user's PATH on typical Linux/macOS setups without needing sudo.
-pub const DEFAULT_REMOTE_BINARY_PATH: &str = "~/.local/bin/emacs-lsp-proxy";
+/// Default location we install the remote binary. Lives under the XDG-style
+/// cache directory so it doesn't pollute the user's PATH — callers invoke it
+/// by absolute path, not by name.
+pub const DEFAULT_REMOTE_BINARY_PATH: &str = "~/.cache/emacs/lsp-proxy/emacs-lsp-proxy";
 
 /// Version expected on the remote side — baked in at compile time so that
 /// upgrading the local crate naturally triggers a redeploy.

--- a/src/remote/deploy.rs
+++ b/src/remote/deploy.rs
@@ -155,8 +155,34 @@ async fn download_release_on_remote(
         return Err(e).context("failed to create remote install directory");
     }
 
-    // 3. Download the archive (curl preferred, wget as fallback).
-    on_progress(format!("Downloading {url}..."));
+    // 3. Get total file size for percentage display (best-effort, not fatal).
+    let total_bytes: u64 = {
+        // `-IL` follows redirects (GitHub releases → CDN 302) so the final
+        // response contains the actual Content-Length.
+        let head_script = format!(
+            "command -v curl >/dev/null 2>&1 && \
+             curl -sIL {url} | grep -i '^content-length:' | tail -1 | \
+             tr -d '\\r' | awk '{{print $2}}' || echo 0",
+            url = shell_escape(&url),
+        );
+        conn.run_command(&format!("sh -c {}", shell_escape(&head_script)))
+            .await
+            .unwrap_or_default()
+            .trim()
+            .parse()
+            .unwrap_or(0)
+    };
+
+    // 4. Download the archive with concurrent progress polling.
+    on_progress(format!(
+        "Downloading {url}{}...",
+        if total_bytes > 0 {
+            format!(" ({:.1} MB)", total_bytes as f64 / 1_048_576.0)
+        } else {
+            String::new()
+        }
+    ));
+
     let dl_script = format!(
         "command -v curl >/dev/null 2>&1 && \
          curl -fSL {url} -o {archive} || \
@@ -164,10 +190,49 @@ async fn download_release_on_remote(
         url     = shell_escape(&url),
         archive = shell_escape(&archive),
     );
-    let output = conn
-        .run_command_with_status(&format!("sh -c {}", shell_escape(&dl_script)))
-        .await
-        .context("download command failed to launch")?;
+    let dl_cmd = format!("sh -c {}", shell_escape(&dl_script));
+
+    // `stat -f%z` is macOS; `stat -c%s` is Linux.  Try both.
+    let size_cmd = format!(
+        "sh -c {}",
+        shell_escape(&format!(
+            "stat -f%z {a} 2>/dev/null || stat -c%s {a} 2>/dev/null || echo 0",
+            a = shell_escape(&archive),
+        )),
+    );
+
+    // Run download and size-polling concurrently.  `select!` cancels the
+    // polling branch as soon as the download future resolves.
+    let output = tokio::select! {
+        result = conn.run_command_with_status(&dl_cmd) => {
+            result.context("download command failed to launch")?
+        }
+        _ = async {
+            let mut interval =
+                tokio::time::interval(std::time::Duration::from_millis(500));
+            loop {
+                interval.tick().await;
+                if let Ok(s) = conn.run_command(&size_cmd).await {
+                    let current: u64 = s.trim().parse().unwrap_or(0);
+                    if current == 0 { continue; }
+                    if total_bytes > 0 {
+                        let pct = (current * 100 / total_bytes).min(99);
+                        on_progress(format!(
+                            "Downloading... {pct}% ({:.1} / {:.1} MB)",
+                            current as f64 / 1_048_576.0,
+                            total_bytes as f64 / 1_048_576.0,
+                        ));
+                    } else {
+                        on_progress(format!(
+                            "Downloading... {:.1} MB",
+                            current as f64 / 1_048_576.0,
+                        ));
+                    }
+                }
+            }
+        } => { unreachable!() }
+    };
+
     if !output.is_success() {
         conn.run_command(&cleanup).await.ok();
         anyhow::bail!(

--- a/src/remote/detector.rs
+++ b/src/remote/detector.rs
@@ -93,7 +93,8 @@ impl RemoteDetector {
     }
 
     /// 将本地路径转换为远程路径表示
-    pub fn local_to_remote_path(&self, local_path: &str, remote_info: &RemoteInfo) -> String {
+    #[allow(dead_code)]
+    pub fn local_to_remote_path(&self, local_path: &str, _remote_info: &RemoteInfo) -> String {
         // 简化实现：直接将本地路径作为远程路径
         // 实际应用中可能需要更复杂的路径映射逻辑
         local_path.to_string()
@@ -129,6 +130,7 @@ impl RemoteDetector {
     }
 
     /// 检查是否为远程路径
+    #[allow(dead_code)]
     pub fn is_remote_path(&self, path: &str) -> bool {
         matches!(self.parse_path(path), RemotePathInfo::Remote(_))
     }
@@ -142,6 +144,7 @@ impl RemoteDetector {
     }
 
     /// 检查路径是否使用指定的远程类型
+    #[allow(dead_code)]
     pub fn is_remote_type(&self, path: &str, remote_type: RemoteType) -> bool {
         if let Some(info) = self.extract_remote_info(path) {
             info.host.remote_type == remote_type

--- a/src/remote/detector.rs
+++ b/src/remote/detector.rs
@@ -1,0 +1,235 @@
+use anyhow::Result;
+use regex::Regex;
+
+use super::{RemoteHost, RemoteType};
+
+/// 远程文件信息
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteInfo {
+    pub host: RemoteHost,
+    pub remote_path: String,
+}
+
+/// 路径信息，可能是本地或远程
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemotePathInfo {
+    Local(String),
+    Remote(RemoteInfo),
+}
+
+/// 远程文件检测器
+pub struct RemoteDetector {
+    ssh_regex: Regex,
+    rpc_regex: Regex,
+}
+
+impl RemoteDetector {
+    pub fn new() -> Result<Self> {
+        // SSH TRAMP 格式: /ssh:user@host:/path/to/file 或 /ssh:user@host#port:/path/to/file
+        let ssh_regex = Regex::new(r"^/ssh:([^@]+)@([^:#]+)(?:#(\d+))?:(.*)$")?;
+
+        // RPC TRAMP 格式: /rpc:user@host:/path/to/file 或 /rpc:user@host#port:/path/to/file
+        let rpc_regex = Regex::new(r"^/rpc:([^@]+)@([^:#]+)(?:#(\d+))?:(.*)$")?;
+
+        Ok(Self {
+            ssh_regex,
+            rpc_regex,
+        })
+    }
+
+    /// 解析路径，判断是本地路径还是远程路径
+    pub fn parse_path(&self, path: &str) -> RemotePathInfo {
+        // 尝试解析 SSH 路径
+        if let Some(captures) = self.ssh_regex.captures(path) {
+            let user = captures.get(1).unwrap().as_str().to_string();
+            let host = captures.get(2).unwrap().as_str().to_string();
+            let port = captures.get(3).map(|m| m.as_str().parse().ok()).flatten();
+            let remote_path = captures.get(4).unwrap().as_str().to_string();
+
+            return RemotePathInfo::Remote(RemoteInfo {
+                host: RemoteHost {
+                    remote_type: RemoteType::Ssh,
+                    user,
+                    host,
+                    port,
+                },
+                remote_path,
+            });
+        }
+
+        // 尝试解析 RPC 路径
+        if let Some(captures) = self.rpc_regex.captures(path) {
+            let user = captures.get(1).unwrap().as_str().to_string();
+            let host = captures.get(2).unwrap().as_str().to_string();
+            let port = captures.get(3).map(|m| m.as_str().parse().ok()).flatten();
+            let remote_path = captures.get(4).unwrap().as_str().to_string();
+
+            return RemotePathInfo::Remote(RemoteInfo {
+                host: RemoteHost {
+                    remote_type: RemoteType::Rpc,
+                    user,
+                    host,
+                    port,
+                },
+                remote_path,
+            });
+        }
+
+        // 默认为本地路径
+        RemotePathInfo::Local(path.to_string())
+    }
+
+    /// 将本地路径转换为远程路径表示
+    pub fn local_to_remote_path(&self, local_path: &str, remote_info: &RemoteInfo) -> String {
+        // 简化实现：直接将本地路径作为远程路径
+        // 实际应用中可能需要更复杂的路径映射逻辑
+        local_path.to_string()
+    }
+
+    /// 将远程路径转换为本地路径表示
+    pub fn remote_to_local_path(&self, remote_info: &RemoteInfo) -> String {
+        // 构造 TRAMP 格式的路径
+        let remote_type_str = match remote_info.host.remote_type {
+            RemoteType::Ssh => "ssh",
+            RemoteType::Rpc => "rpc",
+        };
+
+        match remote_info.host.port {
+            Some(port) => format!(
+                "/{}:{}@{}#{}:{}",
+                remote_type_str,
+                remote_info.host.user,
+                remote_info.host.host,
+                port,
+                remote_info.remote_path
+            ),
+            None => format!(
+                "/{}:{}@{}:{}",
+                remote_type_str,
+                remote_info.host.user,
+                remote_info.host.host,
+                remote_info.remote_path
+            ),
+        }
+    }
+
+    /// 检查是否为远程路径
+    pub fn is_remote_path(&self, path: &str) -> bool {
+        matches!(self.parse_path(path), RemotePathInfo::Remote(_))
+    }
+
+    /// 提取远程信息（如果是远程路径）
+    pub fn extract_remote_info(&self, path: &str) -> Option<RemoteInfo> {
+        match self.parse_path(path) {
+            RemotePathInfo::Remote(info) => Some(info),
+            RemotePathInfo::Local(_) => None,
+        }
+    }
+
+    /// 检查路径是否使用指定的远程类型
+    pub fn is_remote_type(&self, path: &str, remote_type: RemoteType) -> bool {
+        if let Some(info) = self.extract_remote_info(path) {
+            info.host.remote_type == remote_type
+        } else {
+            false
+        }
+    }
+}
+
+impl Default for RemoteDetector {
+    fn default() -> Self {
+        Self::new().expect("Failed to create RemoteDetector")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ssh_path_parsing() {
+        let detector = RemoteDetector::new().unwrap();
+
+        // 测试标准 SSH 路径
+        let path = "/ssh:user@example.com:/home/user/file.txt";
+        match detector.parse_path(path) {
+            RemotePathInfo::Remote(info) => {
+                assert_eq!(info.host.remote_type, RemoteType::Ssh);
+                assert_eq!(info.host.user, "user");
+                assert_eq!(info.host.host, "example.com");
+                assert_eq!(info.host.port, None);
+                assert_eq!(info.remote_path, "/home/user/file.txt");
+            }
+            _ => panic!("Expected remote path"),
+        }
+
+        // 测试带端口的 SSH 路径
+        let path = "/ssh:admin@192.168.1.100#2222:/var/log/test.log";
+        match detector.parse_path(path) {
+            RemotePathInfo::Remote(info) => {
+                assert_eq!(info.host.remote_type, RemoteType::Ssh);
+                assert_eq!(info.host.user, "admin");
+                assert_eq!(info.host.host, "192.168.1.100");
+                assert_eq!(info.host.port, Some(2222));
+                assert_eq!(info.remote_path, "/var/log/test.log");
+            }
+            _ => panic!("Expected remote path"),
+        }
+    }
+
+    #[test]
+    fn test_rpc_path_parsing() {
+        let detector = RemoteDetector::new().unwrap();
+
+        let path = "/rpc:dev@server.local:/project/src/main.rs";
+        match detector.parse_path(path) {
+            RemotePathInfo::Remote(info) => {
+                assert_eq!(info.host.remote_type, RemoteType::Rpc);
+                assert_eq!(info.host.user, "dev");
+                assert_eq!(info.host.host, "server.local");
+                assert_eq!(info.host.port, None);
+                assert_eq!(info.remote_path, "/project/src/main.rs");
+            }
+            _ => panic!("Expected remote path"),
+        }
+    }
+
+    #[test]
+    fn test_local_path_parsing() {
+        let detector = RemoteDetector::new().unwrap();
+
+        let path = "/home/user/local/file.txt";
+        match detector.parse_path(path) {
+            RemotePathInfo::Local(local_path) => {
+                assert_eq!(local_path, "/home/user/local/file.txt");
+            }
+            _ => panic!("Expected local path"),
+        }
+    }
+
+    #[test]
+    fn test_path_conversion() {
+        let detector = RemoteDetector::new().unwrap();
+
+        let remote_info = RemoteInfo {
+            host: RemoteHost {
+                remote_type: RemoteType::Ssh,
+                user: "test".to_string(),
+                host: "example.com".to_string(),
+                port: Some(22),
+            },
+            remote_path: "/home/test/file.rs".to_string(),
+        };
+
+        let tramp_path = detector.remote_to_local_path(&remote_info);
+        assert_eq!(tramp_path, "/ssh:test@example.com#22:/home/test/file.rs");
+
+        // 测试往返转换
+        match detector.parse_path(&tramp_path) {
+            RemotePathInfo::Remote(parsed_info) => {
+                assert_eq!(parsed_info, remote_info);
+            }
+            _ => panic!("Expected remote path after round-trip conversion"),
+        }
+    }
+}

--- a/src/remote/detector.rs
+++ b/src/remote/detector.rs
@@ -25,11 +25,18 @@ pub struct RemoteDetector {
 
 impl RemoteDetector {
     pub fn new() -> Result<Self> {
-        // SSH TRAMP 格式: /ssh:user@host:/path/to/file 或 /ssh:user@host#port:/path/to/file
-        let ssh_regex = Regex::new(r"^/ssh:([^@]+)@([^:#]+)(?:#(\d+))?:(.*)$")?;
-
-        // RPC TRAMP 格式: /rpc:user@host:/path/to/file 或 /rpc:user@host#port:/path/to/file
-        let rpc_regex = Regex::new(r"^/rpc:([^@]+)@([^:#]+)(?:#(\d+))?:(.*)$")?;
+        // 兼容三种情况:
+        //   1. 裸 TRAMP 路径: /ssh:user@host:/path  或  /ssh:host:/path  或
+        //      /ssh:user@host#port:/path
+        //   2. eglot/Emacs 侧经 `file://` 包装的同样路径
+        //   3. RPC 同理
+        // user@ 是可选的(SSH config 别名没有用户名),file:// 前缀也是可选的。
+        let ssh_regex = Regex::new(
+            r"^(?:file://)?/ssh:(?:([^@:/#]+)@)?([^:#/]+)(?:#(\d+))?:(.*)$",
+        )?;
+        let rpc_regex = Regex::new(
+            r"^(?:file://)?/rpc:(?:([^@:/#]+)@)?([^:#/]+)(?:#(\d+))?:(.*)$",
+        )?;
 
         Ok(Self {
             ssh_regex,
@@ -39,11 +46,14 @@ impl RemoteDetector {
 
     /// 解析路径，判断是本地路径还是远程路径
     pub fn parse_path(&self, path: &str) -> RemotePathInfo {
-        // 尝试解析 SSH 路径
+        // 尝试解析 SSH 路径 (user@ 可选, file:// 前缀可选)
         if let Some(captures) = self.ssh_regex.captures(path) {
-            let user = captures.get(1).unwrap().as_str().to_string();
+            let user = captures
+                .get(1)
+                .map(|m| m.as_str().to_string())
+                .unwrap_or_default();
             let host = captures.get(2).unwrap().as_str().to_string();
-            let port = captures.get(3).map(|m| m.as_str().parse().ok()).flatten();
+            let port = captures.get(3).and_then(|m| m.as_str().parse().ok());
             let remote_path = captures.get(4).unwrap().as_str().to_string();
 
             return RemotePathInfo::Remote(RemoteInfo {
@@ -57,11 +67,14 @@ impl RemoteDetector {
             });
         }
 
-        // 尝试解析 RPC 路径
+        // 尝试解析 RPC 路径 (user@ 可选)
         if let Some(captures) = self.rpc_regex.captures(path) {
-            let user = captures.get(1).unwrap().as_str().to_string();
+            let user = captures
+                .get(1)
+                .map(|m| m.as_str().to_string())
+                .unwrap_or_default();
             let host = captures.get(2).unwrap().as_str().to_string();
-            let port = captures.get(3).map(|m| m.as_str().parse().ok()).flatten();
+            let port = captures.get(3).and_then(|m| m.as_str().parse().ok());
             let remote_path = captures.get(4).unwrap().as_str().to_string();
 
             return RemotePathInfo::Remote(RemoteInfo {
@@ -93,22 +106,24 @@ impl RemoteDetector {
             RemoteType::Ssh => "ssh",
             RemoteType::Rpc => "rpc",
         };
-
+        // `user@` 只在有 user 时出现,否则按 TRAMP 的惯例省略。
+        let user_part = if remote_info.host.user.is_empty() {
+            String::new()
+        } else {
+            format!("{}@", remote_info.host.user)
+        };
         match remote_info.host.port {
             Some(port) => format!(
-                "/{}:{}@{}#{}:{}",
+                "/{}:{}{}#{}:{}",
                 remote_type_str,
-                remote_info.host.user,
+                user_part,
                 remote_info.host.host,
                 port,
                 remote_info.remote_path
             ),
             None => format!(
-                "/{}:{}@{}:{}",
-                remote_type_str,
-                remote_info.host.user,
-                remote_info.host.host,
-                remote_info.remote_path
+                "/{}:{}{}:{}",
+                remote_type_str, user_part, remote_info.host.host, remote_info.remote_path
             ),
         }
     }
@@ -205,6 +220,61 @@ mod tests {
             }
             _ => panic!("Expected local path"),
         }
+    }
+
+    #[test]
+    fn ssh_path_without_user_uses_empty_user() {
+        // TRAMP path against an SSH config alias: `/ssh:home:/path/file`.
+        // There's no user@ segment because the alias config has `User …`.
+        let detector = RemoteDetector::new().unwrap();
+        match detector.parse_path("/ssh:home:/Users/jadestrong/proj/file.ts") {
+            RemotePathInfo::Remote(info) => {
+                assert_eq!(info.host.remote_type, RemoteType::Ssh);
+                assert_eq!(info.host.user, "");
+                assert_eq!(info.host.host, "home");
+                assert_eq!(info.host.port, None);
+                assert_eq!(info.remote_path, "/Users/jadestrong/proj/file.ts");
+            }
+            _ => panic!("expected remote"),
+        }
+    }
+
+    #[test]
+    fn file_uri_wrapping_is_accepted() {
+        // eglot's path-to-uri produces `file://` prefix on a TRAMP path.
+        let detector = RemoteDetector::new().unwrap();
+        match detector.parse_path("file:///ssh:home:/Users/jadestrong/proj/file.ts") {
+            RemotePathInfo::Remote(info) => {
+                assert_eq!(info.host.user, "");
+                assert_eq!(info.host.host, "home");
+                assert_eq!(info.remote_path, "/Users/jadestrong/proj/file.ts");
+            }
+            _ => panic!("expected remote"),
+        }
+
+        // file://-wrapped with user@ form.
+        match detector.parse_path("file:///ssh:alice@box:/home/alice/a.py") {
+            RemotePathInfo::Remote(info) => {
+                assert_eq!(info.host.user, "alice");
+                assert_eq!(info.host.host, "box");
+            }
+            _ => panic!("expected remote"),
+        }
+    }
+
+    #[test]
+    fn remote_to_local_omits_at_when_user_empty() {
+        let detector = RemoteDetector::new().unwrap();
+        let info = RemoteInfo {
+            host: RemoteHost {
+                remote_type: RemoteType::Ssh,
+                user: "".to_string(),
+                host: "home".to_string(),
+                port: None,
+            },
+            remote_path: "/a/b.ts".to_string(),
+        };
+        assert_eq!(detector.remote_to_local_path(&info), "/ssh:home:/a/b.ts");
     }
 
     #[test]

--- a/src/remote/detector.rs
+++ b/src/remote/detector.rs
@@ -263,6 +263,29 @@ mod tests {
     }
 
     #[test]
+    fn rpc_with_ip_user_and_realistic_path() {
+        // Exactly the URI emacs-tramp-rpc will hand us in production:
+        //   /rpc:<user>@<ip>:<absolute remote path>
+        // wrapped in file:// by our own path-to-uri.
+        let detector = RemoteDetector::new().unwrap();
+        let uri =
+            "file:///rpc:jadestrong@100.127.163.35:/Users/jadestrong/Documents/Github/vtsls/packages/server/src/index.ts";
+        match detector.parse_path(uri) {
+            RemotePathInfo::Remote(info) => {
+                assert_eq!(info.host.remote_type, RemoteType::Rpc);
+                assert_eq!(info.host.user, "jadestrong");
+                assert_eq!(info.host.host, "100.127.163.35");
+                assert_eq!(info.host.port, None);
+                assert_eq!(
+                    info.remote_path,
+                    "/Users/jadestrong/Documents/Github/vtsls/packages/server/src/index.ts"
+                );
+            }
+            _ => panic!("expected remote, got {:?}", detector.parse_path(uri)),
+        }
+    }
+
+    #[test]
     fn remote_to_local_omits_at_when_user_empty() {
         let detector = RemoteDetector::new().unwrap();
         let info = RemoteInfo {

--- a/src/remote/mod.rs
+++ b/src/remote/mod.rs
@@ -1,16 +1,12 @@
 pub mod deploy;
 pub mod detector;
-pub mod rpc;
 pub mod router;
+pub mod rpc;
 pub mod server;
 pub mod ssh;
 
-pub use detector::{RemoteDetector, RemoteInfo, RemotePathInfo};
 pub use router::RemoteConnectionManager;
-pub use rpc::{RpcClient, RpcServer};
-pub use ssh::{SshConnection, SshConnectionOptions};
 
-use anyhow::Result;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RemoteType {

--- a/src/remote/mod.rs
+++ b/src/remote/mod.rs
@@ -31,9 +31,17 @@ impl RemoteHost {
         } else {
             format!("{}@", self.user)
         };
+        // Include remote_type in the key so `/ssh:user@host:` and
+        // `/rpc:user@host:` don't collapse to the same cached client —
+        // their unsolicited-message bridges rewrite URIs back with
+        // different TRAMP prefixes.
+        let type_str = match self.remote_type {
+            RemoteType::Ssh => "ssh",
+            RemoteType::Rpc => "rpc",
+        };
         match self.port {
-            Some(port) => format!("{}{}:{}", user_part, self.host, port),
-            None => format!("{}{}", user_part, self.host),
+            Some(port) => format!("{}:{}{}:{}", type_str, user_part, self.host, port),
+            None => format!("{}:{}{}", type_str, user_part, self.host),
         }
     }
 }

--- a/src/remote/mod.rs
+++ b/src/remote/mod.rs
@@ -28,9 +28,16 @@ pub struct RemoteHost {
 
 impl RemoteHost {
     pub fn connection_key(&self) -> String {
+        // Empty user means "let ssh resolve via config" — omit the `@` so
+        // the key we cache matches how ssh would see the destination.
+        let user_part = if self.user.is_empty() {
+            String::new()
+        } else {
+            format!("{}@", self.user)
+        };
         match self.port {
-            Some(port) => format!("{}@{}:{}", self.user, self.host, port),
-            None => format!("{}@{}", self.user, self.host),
+            Some(port) => format!("{}{}:{}", user_part, self.host, port),
+            None => format!("{}{}", user_part, self.host),
         }
     }
 }

--- a/src/remote/mod.rs
+++ b/src/remote/mod.rs
@@ -1,0 +1,36 @@
+pub mod deploy;
+pub mod detector;
+pub mod rpc;
+pub mod router;
+pub mod server;
+pub mod ssh;
+
+pub use detector::{RemoteDetector, RemoteInfo, RemotePathInfo};
+pub use router::RemoteConnectionManager;
+pub use rpc::{RpcClient, RpcServer};
+pub use ssh::{SshConnection, SshConnectionOptions};
+
+use anyhow::Result;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteType {
+    Ssh,
+    Rpc,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteHost {
+    pub remote_type: RemoteType,
+    pub user: String,
+    pub host: String,
+    pub port: Option<u16>,
+}
+
+impl RemoteHost {
+    pub fn connection_key(&self) -> String {
+        match self.port {
+            Some(port) => format!("{}@{}:{}", self.user, self.host, port),
+            None => format!("{}@{}", self.user, self.host),
+        }
+    }
+}

--- a/src/remote/router.rs
+++ b/src/remote/router.rs
@@ -45,12 +45,16 @@ impl RemoteConnectionManager {
     }
 
     /// 检查是否为远程路径
+    #[allow(dead_code)]
     pub fn is_remote_path(&self, path: &str) -> bool {
         self.detector.is_remote_path(path)
     }
 
     /// 获取或创建SSH连接
-    async fn get_or_create_ssh_connection(&self, remote_info: &RemoteInfo) -> Result<Arc<SshConnection>> {
+    async fn get_or_create_ssh_connection(
+        &self,
+        remote_info: &RemoteInfo,
+    ) -> Result<Arc<SshConnection>> {
         let connection_key = remote_info.host.connection_key();
 
         let mut connections = self.ssh_connections.lock().await;
@@ -60,10 +64,8 @@ impl RemoteConnectionManager {
         }
 
         // 创建新的SSH连接
-        let options = SshConnectionOptions::new(
-            remote_info.host.host.clone(),
-            remote_info.host.user.clone(),
-        );
+        let options =
+            SshConnectionOptions::new(remote_info.host.host.clone(), remote_info.host.user.clone());
 
         let options = if let Some(port) = remote_info.host.port {
             options.with_port(port)
@@ -71,7 +73,7 @@ impl RemoteConnectionManager {
             options
         };
 
-        info!("Creating new SSH connection to {}", connection_key);
+        info!("Creating new SSH connection to {connection_key}");
         let connection = Arc::new(SshConnection::connect(options).await?);
         connections.insert(connection_key.clone(), connection.clone());
 
@@ -93,8 +95,7 @@ impl RemoteConnectionManager {
             // a fresh tunnel instead of handing back a guaranteed-to-fail
             // client for the rest of the session.
             warn!(
-                "RPC client for {} is dead; evicting and reconnecting",
-                connection_key
+                "RPC client for {connection_key} is dead; evicting and reconnecting"
             );
             clients.remove(&connection_key);
             // A dead RPC client typically means the SSH child exited; the
@@ -111,10 +112,12 @@ impl RemoteConnectionManager {
         let remote_lsp_path = DEFAULT_REMOTE_BINARY_PATH;
         deploy::ensure_remote_binary(ssh_connection.as_ref(), remote_lsp_path)
             .await
-            .map_err(|e| anyhow!("auto-deploy failed for {}: {}", connection_key, e))?;
+            .map_err(|e| anyhow!("auto-deploy failed for {connection_key}: {e}"))?;
 
         // 启动远程LSP代理进程
-        let lsp_process = ssh_connection.start_remote_lsp_proxy(remote_lsp_path).await?;
+        let lsp_process = ssh_connection
+            .start_remote_lsp_proxy(remote_lsp_path)
+            .await?;
 
         // 创建RPC客户端，使用SSH隧道
         let stream = SshRpcStream::from_child_stdio(lsp_process.stdin, lsp_process.stdout);
@@ -144,14 +147,13 @@ impl RemoteConnectionManager {
             None => {
                 warn!(
                     "no result sink set on RemoteConnectionManager; \
-                     server-initiated notifications for {} will be dropped",
-                    connection_key
+                     server-initiated notifications for {connection_key} will be dropped"
                 );
             }
         }
 
         clients.insert(connection_key.clone(), client.clone());
-        info!("Created new RPC client for {}", connection_key);
+        info!("Created new RPC client for {connection_key}");
 
         Ok(client)
     }
@@ -163,7 +165,10 @@ impl RemoteConnectionManager {
         if let Some(path_str) = path {
             match self.detector.parse_path(&path_str) {
                 RemotePathInfo::Remote(remote_info) => {
-                    debug!("Routing message to remote: {}", remote_info.host.connection_key());
+                    debug!(
+                        "Routing message to remote: {}",
+                        remote_info.host.connection_key()
+                    );
                     return self.handle_remote_message(message, remote_info).await;
                 }
                 RemotePathInfo::Local(_) => {
@@ -186,7 +191,8 @@ impl RemoteConnectionManager {
     ) -> Result<Option<Message>> {
         let _ = remote_info.host.remote_type; // variant kept for future diversification
         let client = self.get_or_create_rpc_client(&remote_info).await?;
-        self.handle_message_via_rpc(message, client, remote_info).await
+        self.handle_message_via_rpc(message, client, remote_info)
+            .await
     }
 
     /// 通过RPC处理消息
@@ -219,7 +225,8 @@ impl RemoteConnectionManager {
                     result_preview
                 );
                 // 转换响应中的路径：将远程路径转换回TRAMP路径
-                let transformed_response = self.transform_response_paths_from_remote(response, &remote_info)?;
+                let transformed_response =
+                    self.transform_response_paths_from_remote(response, &remote_info)?;
                 let after_preview = transformed_response
                     .result
                     .as_ref()
@@ -282,7 +289,11 @@ impl RemoteConnectionManager {
     }
 
     /// 转换消息中的路径以适应远程执行
-    fn transform_paths_for_remote(&self, message: Message, remote_info: &RemoteInfo) -> Result<Message> {
+    fn transform_paths_for_remote(
+        &self,
+        message: Message,
+        remote_info: &RemoteInfo,
+    ) -> Result<Message> {
         match message {
             Message::Request(mut req) => {
                 // 转换URI路径
@@ -293,12 +304,14 @@ impl RemoteConnectionManager {
                 }
 
                 // 转换params中的路径
-                req.params.params = self.transform_json_paths_for_remote(req.params.params, remote_info)?;
+                req.params.params =
+                    self.transform_json_paths_for_remote(req.params.params, remote_info)?;
 
                 Ok(Message::Request(req))
             }
             Message::Notification(mut notif) => {
-                notif.params.params = self.transform_json_paths_for_remote(notif.params.params, remote_info)?;
+                notif.params.params =
+                    self.transform_json_paths_for_remote(notif.params.params, remote_info)?;
                 Ok(Message::Notification(notif))
             }
             msg => Ok(msg),
@@ -306,7 +319,11 @@ impl RemoteConnectionManager {
     }
 
     /// 转换响应中的路径
-    fn transform_response_paths_from_remote(&self, mut response: Response, remote_info: &RemoteInfo) -> Result<Response> {
+    fn transform_response_paths_from_remote(
+        &self,
+        mut response: Response,
+        remote_info: &RemoteInfo,
+    ) -> Result<Response> {
         if let Some(result) = response.result {
             response.result = Some(self.transform_json_paths_from_remote(result, remote_info)?);
         }
@@ -314,13 +331,19 @@ impl RemoteConnectionManager {
     }
 
     /// 转换JSON中的路径（远程 -> 本地）
-    fn transform_json_paths_for_remote(&self, mut value: serde_json::Value, remote_info: &RemoteInfo) -> Result<serde_json::Value> {
+    fn transform_json_paths_for_remote(
+        &self,
+        mut value: serde_json::Value,
+        remote_info: &RemoteInfo,
+    ) -> Result<serde_json::Value> {
         match &mut value {
             serde_json::Value::Object(map) => {
                 for (key, val) in map.iter_mut() {
                     if key == "uri" || key.ends_with("Uri") {
                         if let Some(uri_str) = val.as_str() {
-                            if let Some(remote_uri) = self.convert_tramp_to_remote_uri(uri_str, remote_info) {
+                            if let Some(remote_uri) =
+                                self.convert_tramp_to_remote_uri(uri_str, remote_info)
+                            {
                                 *val = serde_json::Value::String(remote_uri);
                             }
                         }
@@ -340,13 +363,19 @@ impl RemoteConnectionManager {
     }
 
     /// 转换JSON中的路径（本地 -> 远程）
-    fn transform_json_paths_from_remote(&self, mut value: serde_json::Value, remote_info: &RemoteInfo) -> Result<serde_json::Value> {
+    fn transform_json_paths_from_remote(
+        &self,
+        mut value: serde_json::Value,
+        remote_info: &RemoteInfo,
+    ) -> Result<serde_json::Value> {
         match &mut value {
             serde_json::Value::Object(map) => {
                 for (key, val) in map.iter_mut() {
                     if key == "uri" || key.ends_with("Uri") {
                         if let Some(uri_str) = val.as_str() {
-                            if let Some(tramp_uri) = self.convert_remote_to_tramp_uri(uri_str, remote_info) {
+                            if let Some(tramp_uri) =
+                                self.convert_remote_to_tramp_uri(uri_str, remote_info)
+                            {
                                 *val = serde_json::Value::String(tramp_uri);
                             }
                         }
@@ -367,8 +396,8 @@ impl RemoteConnectionManager {
 
     /// 将TRAMP URI转换为远程URI
     fn convert_tramp_to_remote_uri(&self, uri: &str, remote_info: &RemoteInfo) -> Option<String> {
-        if uri.starts_with("file://") {
-            let path = &uri[7..]; // 移除 "file://" 前缀
+        if let Some(path) = uri.strip_prefix("file://") {
+            // 移除 "file://" 前缀
             if let Some(remote_info_from_path) = self.detector.extract_remote_info(path) {
                 if remote_info_from_path.host == remote_info.host {
                     // 转换为远程文件URI
@@ -381,18 +410,62 @@ impl RemoteConnectionManager {
 
     /// 将远程URI转换为TRAMP URI
     fn convert_remote_to_tramp_uri(&self, uri: &str, remote_info: &RemoteInfo) -> Option<String> {
-        if uri.starts_with("file://") {
-            let remote_path = &uri[7..]; // 移除 "file://" 前缀
+        if let Some(remote_path) = uri.strip_prefix("file://") {
+            // 移除 "file://" 前缀
             let tramp_path = self.detector.remote_to_local_path(&RemoteInfo {
                 host: remote_info.host.clone(),
                 remote_path: remote_path.to_string(),
             });
-            return Some(format!("file://{}", tramp_path));
+            return Some(format!("file://{tramp_path}"));
         }
         None
     }
 
+    /// Collect diagnostic status of all RPC clients for `emacs/getRemoteInfo`.
+    pub async fn get_remote_status(&self) -> crate::lsp_ext::RemoteConnectionStatus {
+        let clients = self.rpc_clients.lock().await;
+        let ssh_conns = self.ssh_connections.lock().await;
+        let mut infos = Vec::new();
+        for (key, client) in clients.iter() {
+            // Probe deployment status via the SSH connection for this key.
+            let remote_path = deploy::DEFAULT_REMOTE_BINARY_PATH;
+            let (deploy_status, remote_version) = match ssh_conns.get(key) {
+                Some(ssh) => match deploy::check_remote_binary(ssh, remote_path).await {
+                    Ok(deploy::RemoteBinaryStatus::VersionMatch) => {
+                        ("deployed".to_string(), Some(deploy::EXPECTED_VERSION.to_string()))
+                    }
+                    Ok(deploy::RemoteBinaryStatus::VersionMismatch { remote }) => {
+                        ("version_mismatch".to_string(), Some(remote))
+                    }
+                    Ok(deploy::RemoteBinaryStatus::Missing) => {
+                        ("missing".to_string(), None)
+                    }
+                    Err(e) => {
+                        warn!("failed to probe remote binary for {key}: {e}");
+                        ("unknown".to_string(), None)
+                    }
+                },
+                None => ("unknown".to_string(), None),
+            };
+
+            infos.push(crate::lsp_ext::RemoteClientInfo {
+                connection_key: key.clone(),
+                remote_type: "rpc".to_string(),
+                is_alive: !client.is_dead(),
+                binary_path: remote_path.to_string(),
+                local_version: deploy::EXPECTED_VERSION.to_string(),
+                remote_version,
+                deploy_status,
+            });
+        }
+        crate::lsp_ext::RemoteConnectionStatus {
+            enabled: true,
+            clients: infos,
+        }
+    }
+
     /// 清理资源
+    #[allow(dead_code)]
     pub async fn cleanup(&self) {
         // 清理SSH连接
         let mut connections = self.ssh_connections.lock().await;
@@ -478,7 +551,7 @@ fn local_file_uri_to_tramp(uri: &str, remote_info: &RemoteInfo) -> Option<String
             type_str, user_part, remote_info.host.host, remote_path
         ),
     };
-    Some(format!("file://{}", tramp))
+    Some(format!("file://{tramp}"))
 }
 
 /// SSH RPC 流适配器 — 把子进程的 stdin/stdout 组合成一个同时实现
@@ -572,9 +645,7 @@ mod tests {
         assert!(m
             .convert_tramp_to_remote_uri("file:///home/alice/local.py", &info)
             .is_none());
-        assert!(m
-            .convert_tramp_to_remote_uri("/not/a/uri", &info)
-            .is_none());
+        assert!(m.convert_tramp_to_remote_uri("/not/a/uri", &info).is_none());
     }
 
     #[test]
@@ -666,7 +737,8 @@ mod tests {
         rewrite_to_tramp(&mut msg, &remote_info);
 
         let expected = "file:///rpc:jadestrong@100.127.163.35:/Users/jadestrong/proj/file.ts";
-        let expected_other = "file:///rpc:jadestrong@100.127.163.35:/Users/jadestrong/proj/other.ts";
+        let expected_other =
+            "file:///rpc:jadestrong@100.127.163.35:/Users/jadestrong/proj/other.ts";
         match msg {
             crate::msg::Message::Notification(n) => {
                 assert_eq!(n.params.uri.as_deref(), Some(expected));
@@ -705,7 +777,10 @@ mod tests {
             "position": {"line": 0, "character": 0}
         });
         let extracted = m.extract_uri_from_params(&params);
-        assert_eq!(extracted.as_deref(), Some("/ssh:alice@box:/home/alice/x.py"));
+        assert_eq!(
+            extracted.as_deref(),
+            Some("/ssh:alice@box:/home/alice/x.py")
+        );
     }
 }
 

--- a/src/remote/router.rs
+++ b/src/remote/router.rs
@@ -8,7 +8,7 @@ use tokio::sync::Mutex;
 use tokio_util::compat::{Compat, TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use super::{
-    deploy::{self, DEFAULT_REMOTE_BINARY_PATH},
+    deploy,
     detector::{RemoteDetector, RemoteInfo, RemotePathInfo},
     rpc::RpcClient,
     ssh::{SshConnection, SshConnectionOptions},
@@ -109,7 +109,7 @@ impl RemoteConnectionManager {
         let ssh_connection = self.get_or_create_ssh_connection(remote_info).await?;
 
         // 在启动远程进程前,先确保远端 binary 存在且版本匹配,否则 scp 过去
-        let remote_lsp_path = DEFAULT_REMOTE_BINARY_PATH;
+        let remote_lsp_path = crate::config::remote_binary_path();
         deploy::ensure_remote_binary(ssh_connection.as_ref(), remote_lsp_path)
             .await
             .map_err(|e| anyhow!("auto-deploy failed for {connection_key}: {e}"))?;
@@ -428,7 +428,7 @@ impl RemoteConnectionManager {
         let mut infos = Vec::new();
         for (key, client) in clients.iter() {
             // Probe deployment status via the SSH connection for this key.
-            let remote_path = deploy::DEFAULT_REMOTE_BINARY_PATH;
+            let remote_path = crate::config::remote_binary_path();
             let (deploy_status, remote_version) = match ssh_conns.get(key) {
                 Some(ssh) => match deploy::check_remote_binary(ssh, remote_path).await {
                     Ok(deploy::RemoteBinaryStatus::VersionMatch) => {

--- a/src/remote/router.rs
+++ b/src/remote/router.rs
@@ -12,6 +12,7 @@ use super::{
     detector::{RemoteDetector, RemoteInfo, RemotePathInfo},
     rpc::RpcClient,
     ssh::{SshConnection, SshConnectionOptions},
+    RemoteType,
 };
 use crate::msg::{Message, Response};
 
@@ -20,6 +21,10 @@ pub struct RemoteConnectionManager {
     detector: RemoteDetector,
     ssh_connections: Arc<Mutex<HashMap<String, Arc<SshConnection>>>>,
     rpc_clients: Arc<Mutex<HashMap<String, Arc<RpcClient>>>>,
+    /// Where path-corrected server-initiated messages get pushed. Set once
+    /// by the Controller during startup; each new RpcClient spawns a bridge
+    /// task that drains its unsolicited channel into this sink.
+    result_sink: Arc<parking_lot::Mutex<Option<crossbeam_channel::Sender<Message>>>>,
 }
 
 impl RemoteConnectionManager {
@@ -28,7 +33,15 @@ impl RemoteConnectionManager {
             detector: RemoteDetector::new()?,
             ssh_connections: Arc::new(Mutex::new(HashMap::new())),
             rpc_clients: Arc::new(Mutex::new(HashMap::new())),
+            result_sink: Arc::new(parking_lot::Mutex::new(None)),
         })
+    }
+
+    /// Install the channel used to deliver server-initiated notifications /
+    /// requests back to the Controller (and from there to Emacs). Must be
+    /// called before the first remote connection is opened.
+    pub fn set_result_sink(&self, sink: crossbeam_channel::Sender<Message>) {
+        *self.result_sink.lock() = Some(sink);
     }
 
     /// 检查是否为远程路径
@@ -89,7 +102,37 @@ impl RemoteConnectionManager {
 
         // 创建RPC客户端，使用SSH隧道
         let stream = SshRpcStream::from_child_stdio(lsp_process.stdin, lsp_process.stdout);
-        let client = Arc::new(RpcClient::new(stream)?);
+
+        // Set up the unsolicited-message bridge: the RpcClient pushes raw
+        // server-initiated messages into a per-client tokio channel, and we
+        // spawn a small task that rewrites URIs to TRAMP form and forwards
+        // them to the Controller's result sink.
+        let (unsolicited_tx, mut unsolicited_rx) =
+            tokio::sync::mpsc::unbounded_channel::<Message>();
+        let client = Arc::new(RpcClient::new(stream, Some(unsolicited_tx))?);
+
+        let sink_snapshot = self.result_sink.lock().clone();
+        match sink_snapshot {
+            Some(sink) => {
+                let ri = remote_info.clone();
+                tokio::spawn(async move {
+                    while let Some(mut msg) = unsolicited_rx.recv().await {
+                        rewrite_to_tramp(&mut msg, &ri);
+                        if sink.send(msg).is_err() {
+                            debug!("controller result channel closed; stopping bridge");
+                            break;
+                        }
+                    }
+                });
+            }
+            None => {
+                warn!(
+                    "no result sink set on RemoteConnectionManager; \
+                     server-initiated notifications for {} will be dropped",
+                    connection_key
+                );
+            }
+        }
 
         clients.insert(connection_key.clone(), client.clone());
         info!("Created new RPC client for {}", connection_key);
@@ -319,6 +362,81 @@ impl RemoteConnectionManager {
     }
 }
 
+/// Rewrite every `uri` field inside a server-originated Message so Emacs sees
+/// a TRAMP path (`file:///rpc:user@host:/abs/path`) instead of the bare local
+/// path the remote LSP uses internally (`file:///abs/path`).
+///
+/// Applies to both the top-level `Params.uri` and URIs nested anywhere inside
+/// `Params.params` JSON (LSP's position/range/textDocument/locationLink etc.).
+fn rewrite_to_tramp(msg: &mut Message, remote_info: &RemoteInfo) {
+    let params = match msg {
+        Message::Notification(n) => &mut n.params,
+        Message::Request(r) => &mut r.params,
+        Message::Response(_) => return,
+    };
+    if let Some(uri) = params.uri.as_deref() {
+        if let Some(new) = local_file_uri_to_tramp(uri, remote_info) {
+            params.uri = Some(new);
+        }
+    }
+    rewrite_uris_in_json(&mut params.params, remote_info);
+}
+
+fn rewrite_uris_in_json(value: &mut serde_json::Value, remote_info: &RemoteInfo) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, val) in map.iter_mut() {
+                let is_uri_key = key == "uri" || key.ends_with("Uri");
+                if is_uri_key {
+                    if let Some(s) = val.as_str() {
+                        if let Some(new) = local_file_uri_to_tramp(s, remote_info) {
+                            *val = serde_json::Value::String(new);
+                        }
+                    } else {
+                        // Non-string uri field (rare, but defensively recurse).
+                        rewrite_uris_in_json(val, remote_info);
+                    }
+                } else {
+                    rewrite_uris_in_json(val, remote_info);
+                }
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for item in arr.iter_mut() {
+                rewrite_uris_in_json(item, remote_info);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// `file:///abs/path` → `file:///rpc:user@host:/abs/path` (or /ssh:, depending
+/// on remote_info). Returns None when the input isn't a `file://` URI, so the
+/// caller knows to leave it alone.
+fn local_file_uri_to_tramp(uri: &str, remote_info: &RemoteInfo) -> Option<String> {
+    let remote_path = uri.strip_prefix("file://")?;
+    let type_str = match remote_info.host.remote_type {
+        RemoteType::Ssh => "ssh",
+        RemoteType::Rpc => "rpc",
+    };
+    let user_part = if remote_info.host.user.is_empty() {
+        String::new()
+    } else {
+        format!("{}@", remote_info.host.user)
+    };
+    let tramp = match remote_info.host.port {
+        Some(port) => format!(
+            "/{}:{}{}#{}:{}",
+            type_str, user_part, remote_info.host.host, port, remote_path
+        ),
+        None => format!(
+            "/{}:{}{}:{}",
+            type_str, user_part, remote_info.host.host, remote_path
+        ),
+    };
+    Some(format!("file://{}", tramp))
+}
+
 /// SSH RPC 流适配器 — 把子进程的 stdin/stdout 组合成一个同时实现
 /// `futures::AsyncRead` 和 `futures::AsyncWrite` 的双向流。
 ///
@@ -466,6 +584,72 @@ mod tests {
         assert_eq!(
             transformed[1]["uri"],
             "file:///ssh:alice@box:/home/alice/b.py"
+        );
+    }
+
+    #[test]
+    fn unsolicited_notification_rewrites_nested_uris_to_tramp() {
+        // Simulate what arrives from the remote LSP: a publishDiagnostics
+        // notification referencing the on-remote absolute path. The bridge
+        // must rewrite it to the TRAMP form Emacs is visiting.
+        let remote_info = RemoteInfo {
+            host: super::super::RemoteHost {
+                remote_type: RemoteType::Rpc,
+                user: "jadestrong".to_string(),
+                host: "100.127.163.35".to_string(),
+                port: None,
+            },
+            remote_path: "/".to_string(),
+        };
+
+        let mut msg = crate::msg::Message::Notification(crate::msg::Notification {
+            method: "textDocument/publishDiagnostics".to_string(),
+            params: crate::msg::Params {
+                uri: Some("file:///Users/jadestrong/proj/file.ts".to_string()),
+                context: None,
+                virtual_doc: None,
+                params: serde_json::json!({
+                    "uri": "file:///Users/jadestrong/proj/file.ts",
+                    "diagnostics": [
+                        { "relatedInformation": [
+                            { "location": { "uri": "file:///Users/jadestrong/proj/other.ts" } }
+                        ]}
+                    ]
+                }),
+            },
+        });
+
+        rewrite_to_tramp(&mut msg, &remote_info);
+
+        let expected = "file:///rpc:jadestrong@100.127.163.35:/Users/jadestrong/proj/file.ts";
+        let expected_other = "file:///rpc:jadestrong@100.127.163.35:/Users/jadestrong/proj/other.ts";
+        match msg {
+            crate::msg::Message::Notification(n) => {
+                assert_eq!(n.params.uri.as_deref(), Some(expected));
+                assert_eq!(n.params.params["uri"], expected);
+                assert_eq!(
+                    n.params.params["diagnostics"][0]["relatedInformation"][0]["location"]["uri"],
+                    expected_other
+                );
+            }
+            _ => panic!("expected notification"),
+        }
+    }
+
+    #[test]
+    fn local_file_uri_to_tramp_for_ssh_alias_without_user() {
+        let info = RemoteInfo {
+            host: super::super::RemoteHost {
+                remote_type: RemoteType::Ssh,
+                user: "".to_string(),
+                host: "home".to_string(),
+                port: None,
+            },
+            remote_path: "/".to_string(),
+        };
+        assert_eq!(
+            local_file_uri_to_tramp("file:///Users/me/a.ts", &info).as_deref(),
+            Some("file:///ssh:home:/Users/me/a.ts"),
         );
     }
 

--- a/src/remote/router.rs
+++ b/src/remote/router.rs
@@ -1,16 +1,5 @@
 use anyhow::{anyhow, Result};
 use log::{debug, info, warn};
-
-/// Truncate `s` to at most `max_bytes` bytes, respecting UTF-8 character boundaries.
-fn truncate_preview(s: &str, max_bytes: usize) -> &str {
-    if s.len() <= max_bytes {
-        return s;
-    }
-    match s.char_indices().map(|(i, _)| i).take_while(|&i| i <= max_bytes).last() {
-        Some(i) if i < s.len() => &s[..i],
-        _ => &s[..max_bytes],
-    }
-}
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -250,7 +239,7 @@ impl RemoteConnectionManager {
                     .as_ref()
                     .map(|v| {
                         let s = v.to_string();
-                        truncate_preview(&s, 256).to_string()
+                        crate::utils::truncate_preview(&s, 256).to_string()
                     })
                     .unwrap_or_else(|| "<none>".into());
                 debug!(
@@ -268,7 +257,7 @@ impl RemoteConnectionManager {
                     .as_ref()
                     .map(|v| {
                         let s = v.to_string();
-                        truncate_preview(&s, 256).to_string()
+                        crate::utils::truncate_preview(&s, 256).to_string()
                     })
                     .unwrap_or_else(|| "<none>".into());
                 debug!(

--- a/src/remote/router.rs
+++ b/src/remote/router.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use log::{debug, info, warn};
 use std::collections::HashMap;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::Arc;
 use std::task::Poll;
 use tokio::sync::Mutex;
 use tokio_util::compat::{Compat, TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
@@ -140,7 +140,7 @@ impl RemoteConnectionManager {
             .start_remote_lsp_proxy(&binary_cmd)
             .await?;
 
-        let (stream, process_handle) = SshRpcStream::from_child_stdio(
+        let stream = SshRpcStream::from_child_stdio(
             lsp_process.stdin,
             lsp_process.stdout,
             lsp_process.process,
@@ -152,11 +152,7 @@ impl RemoteConnectionManager {
         // them to the Controller's result sink.
         let (unsolicited_tx, mut unsolicited_rx) =
             tokio::sync::mpsc::unbounded_channel::<Message>();
-        let client = Arc::new(RpcClient::new_with_transport_killer(
-            stream,
-            Some(unsolicited_tx),
-            Some(Arc::new(move || process_handle.kill_sync())),
-        )?);
+        let client = Arc::new(RpcClient::new(stream, Some(unsolicited_tx))?);
 
         let sink_snapshot = self.result_sink.lock().clone();
         match sink_snapshot {
@@ -655,37 +651,25 @@ impl RemoteConnectionManager {
     /// slave process that carries a remote RPC stream, then shut down the SSH
     /// ControlMaster.
     pub fn kill_all_sync(&self) {
-        if let Ok(clients) = self.rpc_clients.try_lock() {
-            for client in clients.values() {
-                client.kill_transport_sync();
-            }
-        }
+        // `kill_master_sync` handles everything: it pkill's the remote process
+        // directly (most reliable on macOS), then gracefully closes the
+        // ControlMaster.  The SSH slave process is handled by kill_on_drop
+        // when the tokio runtime naturally cleans up.
         if let Ok(connections) = self.ssh_connections.try_lock() {
             for conn in connections.values() {
                 conn.kill_master_sync();
             }
         }
-        info!("kill_all_sync: remote RPC transports and ControlMaster processes signalled");
+        info!("kill_all_sync: ControlMaster processes signalled");
     }
 
     /// Close all active connections in the correct order:
     /// RPC clients first (EOF to remote process), then SSH connections (ControlMaster).
     pub async fn cleanup(&self) {
-        // 1. Kill RPC transports first.  This terminates the local SSH slave
-        //    process carrying the remote `emacs-lsp-proxy --remote-server`
-        //    before the ControlMaster is torn down.
-        {
-            let mut clients = self.rpc_clients.lock().await;
-            for client in clients.values() {
-                client.kill_transport_sync();
-            }
-            clients.clear();
-        }
-
-        // 2. Drop SSH connections — kills the ControlMaster after children
-        //    have already been signalled.
+        // RPC clients first so kill_on_drop fires on the SSH slave before the
+        // ControlMaster is torn down.
+        self.rpc_clients.lock().await.clear();
         self.ssh_connections.lock().await.clear();
-
         info!("Remote connections cleaned up");
     }
 }
@@ -775,26 +759,11 @@ pub struct SshRpcStream {
     reader: Compat<tokio::process::ChildStdout>,
     writer: Compat<tokio::process::ChildStdin>,
     /// The local SSH slave process that carries the tunnel.  Kept here so its
-    /// lifetime matches the stream.  A clone of the handle is also stored on
-    /// the `RpcClient` so shutdown paths that call `process::exit()` can kill
-    /// the process synchronously without relying on Drop.
-    _process: SshRpcProcessHandle,
-}
-
-#[derive(Clone)]
-pub struct SshRpcProcessHandle {
-    process: Arc<StdMutex<Option<tokio::process::Child>>>,
-}
-
-impl SshRpcProcessHandle {
-    pub fn kill_sync(&self) {
-        if let Ok(mut guard) = self.process.lock() {
-            if let Some(child) = guard.as_mut() {
-                let _ = child.start_kill();
-            }
-            *guard = None;
-        }
-    }
+    /// lifetime matches the stream: when `SshRpcStream` is dropped (i.e. when
+    /// the `RpcClient` is dropped), the process is automatically killed via
+    /// `kill_on_drop`.  This ensures the remote `emacs-lsp-proxy --remote-server`
+    /// loses its connection and exits before the SSH ControlMaster is torn down.
+    _process: tokio::process::Child,
 }
 
 impl SshRpcStream {
@@ -802,16 +771,12 @@ impl SshRpcStream {
         stdin: tokio::process::ChildStdin,
         stdout: tokio::process::ChildStdout,
         process: tokio::process::Child,
-    ) -> (Self, SshRpcProcessHandle) {
-        let process = SshRpcProcessHandle {
-            process: Arc::new(StdMutex::new(Some(process))),
-        };
-        let stream = Self {
+    ) -> Self {
+        Self {
             reader: stdout.compat(),
             writer: stdin.compat_write(),
-            _process: process.clone(),
-        };
-        (stream, process)
+            _process: process,
+        }
     }
 }
 

--- a/src/remote/router.rs
+++ b/src/remote/router.rs
@@ -1,0 +1,513 @@
+use anyhow::{anyhow, Result};
+use log::{debug, info, warn};
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::Poll;
+use tokio::sync::Mutex;
+use tokio_util::compat::{Compat, TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+use super::{
+    deploy::{self, DEFAULT_REMOTE_BINARY_PATH},
+    detector::{RemoteDetector, RemoteInfo, RemotePathInfo},
+    rpc::RpcClient,
+    ssh::{SshConnection, SshConnectionOptions},
+    RemoteType,
+};
+use crate::msg::{Message, Response};
+
+/// 远程连接管理器
+pub struct RemoteConnectionManager {
+    detector: RemoteDetector,
+    ssh_connections: Arc<Mutex<HashMap<String, Arc<SshConnection>>>>,
+    rpc_clients: Arc<Mutex<HashMap<String, Arc<RpcClient>>>>,
+}
+
+impl RemoteConnectionManager {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            detector: RemoteDetector::new()?,
+            ssh_connections: Arc::new(Mutex::new(HashMap::new())),
+            rpc_clients: Arc::new(Mutex::new(HashMap::new())),
+        })
+    }
+
+    /// 检查是否为远程路径
+    pub fn is_remote_path(&self, path: &str) -> bool {
+        self.detector.is_remote_path(path)
+    }
+
+    /// 获取或创建SSH连接
+    async fn get_or_create_ssh_connection(&self, remote_info: &RemoteInfo) -> Result<Arc<SshConnection>> {
+        let connection_key = remote_info.host.connection_key();
+
+        let mut connections = self.ssh_connections.lock().await;
+
+        if let Some(connection) = connections.get(&connection_key) {
+            return Ok(connection.clone());
+        }
+
+        // 创建新的SSH连接
+        let options = SshConnectionOptions::new(
+            remote_info.host.host.clone(),
+            remote_info.host.user.clone(),
+        );
+
+        let options = if let Some(port) = remote_info.host.port {
+            options.with_port(port)
+        } else {
+            options
+        };
+
+        info!("Creating new SSH connection to {}", connection_key);
+        let connection = Arc::new(SshConnection::connect(options).await?);
+        connections.insert(connection_key.clone(), connection.clone());
+
+        Ok(connection)
+    }
+
+    /// 获取或创建RPC客户端
+    async fn get_or_create_rpc_client(&self, remote_info: &RemoteInfo) -> Result<Arc<RpcClient>> {
+        let connection_key = remote_info.host.connection_key();
+
+        let mut clients = self.rpc_clients.lock().await;
+
+        if let Some(client) = clients.get(&connection_key) {
+            return Ok(client.clone());
+        }
+
+        // 通过SSH启动远程LSP代理并创建RPC客户端
+        let ssh_connection = self.get_or_create_ssh_connection(remote_info).await?;
+
+        // 在启动远程进程前,先确保远端 binary 存在且版本匹配,否则 scp 过去
+        let remote_lsp_path = DEFAULT_REMOTE_BINARY_PATH;
+        deploy::ensure_remote_binary(ssh_connection.as_ref(), remote_lsp_path)
+            .await
+            .map_err(|e| anyhow!("auto-deploy failed for {}: {}", connection_key, e))?;
+
+        // 启动远程LSP代理进程
+        let lsp_process = ssh_connection.start_remote_lsp_proxy(remote_lsp_path).await?;
+
+        // 创建RPC客户端，使用SSH隧道
+        let stream = SshRpcStream::from_child_stdio(lsp_process.stdin, lsp_process.stdout);
+        let client = Arc::new(RpcClient::new(stream)?);
+
+        clients.insert(connection_key.clone(), client.clone());
+        info!("Created new RPC client for {}", connection_key);
+
+        Ok(client)
+    }
+
+    /// 路由消息到适当的后端
+    pub async fn route_message(&self, message: Message) -> Result<Option<Message>> {
+        let path = self.extract_path_from_message(&message);
+
+        if let Some(path_str) = path {
+            match self.detector.parse_path(&path_str) {
+                RemotePathInfo::Remote(remote_info) => {
+                    debug!("Routing message to remote: {}", remote_info.host.connection_key());
+                    return self.handle_remote_message(message, remote_info).await;
+                }
+                RemotePathInfo::Local(_) => {
+                    // 本地路径，返回None表示由本地处理
+                    return Ok(None);
+                }
+            }
+        }
+
+        // 没有路径信息或无法解析，本地处理
+        Ok(None)
+    }
+
+    /// 处理远程消息
+    async fn handle_remote_message(&self, message: Message, remote_info: RemoteInfo) -> Result<Option<Message>> {
+        match remote_info.host.remote_type {
+            RemoteType::Ssh => {
+                // SSH类型使用RPC客户端
+                let client = self.get_or_create_rpc_client(&remote_info).await?;
+                self.handle_message_via_rpc(message, client, remote_info).await
+            }
+            RemoteType::Rpc => {
+                // 直接RPC连接（暂未实现）
+                Err(anyhow!("Direct RPC connections not yet implemented"))
+            }
+        }
+    }
+
+    /// 通过RPC处理消息
+    async fn handle_message_via_rpc(
+        &self,
+        message: Message,
+        client: Arc<RpcClient>,
+        remote_info: RemoteInfo,
+    ) -> Result<Option<Message>> {
+        // 转换路径：将TRAMP路径转换为远程路径
+        let transformed_message = self.transform_paths_for_remote(message, &remote_info)?;
+
+        match transformed_message {
+            Message::Request(request) => {
+                let response = client.send_request(request).await?;
+                // 转换响应中的路径：将远程路径转换回TRAMP路径
+                let transformed_response = self.transform_response_paths_from_remote(response, &remote_info)?;
+                Ok(Some(Message::Response(transformed_response)))
+            }
+            Message::Notification(notification) => {
+                client.send_notification(notification)?;
+                Ok(None) // 通知不需要响应
+            }
+            Message::Response(_) => {
+                warn!("Received response message for routing, this should not happen");
+                Ok(None)
+            }
+        }
+    }
+
+    /// 从消息中提取文件路径
+    fn extract_path_from_message(&self, message: &Message) -> Option<String> {
+        match message {
+            Message::Request(req) => {
+                // 从请求参数中提取URI
+                if let Some(uri) = &req.params.uri {
+                    Some(uri.clone())
+                } else {
+                    // 尝试从params中提取textDocument.uri
+                    self.extract_uri_from_params(&req.params.params)
+                }
+            }
+            Message::Notification(notif) => {
+                // 从通知参数中提取URI
+                self.extract_uri_from_params(&notif.params.params)
+            }
+            _ => None,
+        }
+    }
+
+    /// 从JSON参数中提取URI
+    fn extract_uri_from_params(&self, params: &serde_json::Value) -> Option<String> {
+        // 尝试多种路径提取方式
+        if let Some(text_doc) = params.get("textDocument") {
+            if let Some(uri) = text_doc.get("uri") {
+                return uri.as_str().map(|s| s.to_string());
+            }
+        }
+
+        if let Some(uri) = params.get("uri") {
+            return uri.as_str().map(|s| s.to_string());
+        }
+
+        None
+    }
+
+    /// 转换消息中的路径以适应远程执行
+    fn transform_paths_for_remote(&self, message: Message, remote_info: &RemoteInfo) -> Result<Message> {
+        match message {
+            Message::Request(mut req) => {
+                // 转换URI路径
+                if let Some(uri) = &req.params.uri {
+                    if let Some(remote_uri) = self.convert_tramp_to_remote_uri(uri, remote_info) {
+                        req.params.uri = Some(remote_uri);
+                    }
+                }
+
+                // 转换params中的路径
+                req.params.params = self.transform_json_paths_for_remote(req.params.params, remote_info)?;
+
+                Ok(Message::Request(req))
+            }
+            Message::Notification(mut notif) => {
+                notif.params.params = self.transform_json_paths_for_remote(notif.params.params, remote_info)?;
+                Ok(Message::Notification(notif))
+            }
+            msg => Ok(msg),
+        }
+    }
+
+    /// 转换响应中的路径
+    fn transform_response_paths_from_remote(&self, mut response: Response, remote_info: &RemoteInfo) -> Result<Response> {
+        if let Some(result) = response.result {
+            response.result = Some(self.transform_json_paths_from_remote(result, remote_info)?);
+        }
+        Ok(response)
+    }
+
+    /// 转换JSON中的路径（远程 -> 本地）
+    fn transform_json_paths_for_remote(&self, mut value: serde_json::Value, remote_info: &RemoteInfo) -> Result<serde_json::Value> {
+        match &mut value {
+            serde_json::Value::Object(map) => {
+                for (key, val) in map.iter_mut() {
+                    if key == "uri" || key.ends_with("Uri") {
+                        if let Some(uri_str) = val.as_str() {
+                            if let Some(remote_uri) = self.convert_tramp_to_remote_uri(uri_str, remote_info) {
+                                *val = serde_json::Value::String(remote_uri);
+                            }
+                        }
+                    } else {
+                        *val = self.transform_json_paths_for_remote(val.clone(), remote_info)?;
+                    }
+                }
+            }
+            serde_json::Value::Array(arr) => {
+                for item in arr.iter_mut() {
+                    *item = self.transform_json_paths_for_remote(item.clone(), remote_info)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(value)
+    }
+
+    /// 转换JSON中的路径（本地 -> 远程）
+    fn transform_json_paths_from_remote(&self, mut value: serde_json::Value, remote_info: &RemoteInfo) -> Result<serde_json::Value> {
+        match &mut value {
+            serde_json::Value::Object(map) => {
+                for (key, val) in map.iter_mut() {
+                    if key == "uri" || key.ends_with("Uri") {
+                        if let Some(uri_str) = val.as_str() {
+                            if let Some(tramp_uri) = self.convert_remote_to_tramp_uri(uri_str, remote_info) {
+                                *val = serde_json::Value::String(tramp_uri);
+                            }
+                        }
+                    } else {
+                        *val = self.transform_json_paths_from_remote(val.clone(), remote_info)?;
+                    }
+                }
+            }
+            serde_json::Value::Array(arr) => {
+                for item in arr.iter_mut() {
+                    *item = self.transform_json_paths_from_remote(item.clone(), remote_info)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(value)
+    }
+
+    /// 将TRAMP URI转换为远程URI
+    fn convert_tramp_to_remote_uri(&self, uri: &str, remote_info: &RemoteInfo) -> Option<String> {
+        if uri.starts_with("file://") {
+            let path = &uri[7..]; // 移除 "file://" 前缀
+            if let Some(remote_info_from_path) = self.detector.extract_remote_info(path) {
+                if remote_info_from_path.host == remote_info.host {
+                    // 转换为远程文件URI
+                    return Some(format!("file://{}", remote_info_from_path.remote_path));
+                }
+            }
+        }
+        None
+    }
+
+    /// 将远程URI转换为TRAMP URI
+    fn convert_remote_to_tramp_uri(&self, uri: &str, remote_info: &RemoteInfo) -> Option<String> {
+        if uri.starts_with("file://") {
+            let remote_path = &uri[7..]; // 移除 "file://" 前缀
+            let tramp_path = self.detector.remote_to_local_path(&RemoteInfo {
+                host: remote_info.host.clone(),
+                remote_path: remote_path.to_string(),
+            });
+            return Some(format!("file://{}", tramp_path));
+        }
+        None
+    }
+
+    /// 清理资源
+    pub async fn cleanup(&self) {
+        // 清理SSH连接
+        let mut connections = self.ssh_connections.lock().await;
+        connections.clear();
+
+        // 清理RPC客户端
+        let mut clients = self.rpc_clients.lock().await;
+        clients.clear();
+
+        info!("Remote connections cleaned up");
+    }
+}
+
+/// SSH RPC 流适配器 — 把子进程的 stdin/stdout 组合成一个同时实现
+/// `futures::AsyncRead` 和 `futures::AsyncWrite` 的双向流。
+///
+/// 内部通过 `tokio_util::compat::Compat` 把 tokio 的 AsyncRead/AsyncWrite
+/// 转换成 futures 版本,避免自己手写 `poll_*` 里的 ReadBuf / wake 细节。
+pub struct SshRpcStream {
+    reader: Compat<tokio::process::ChildStdout>,
+    writer: Compat<tokio::process::ChildStdin>,
+}
+
+impl SshRpcStream {
+    pub fn from_child_stdio(
+        stdin: tokio::process::ChildStdin,
+        stdout: tokio::process::ChildStdout,
+    ) -> Self {
+        Self {
+            reader: stdout.compat(),
+            writer: stdin.compat_write(),
+        }
+    }
+}
+
+impl futures::AsyncRead for SshRpcStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.reader).poll_read(cx, buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::remote::{RemoteHost, RemoteType};
+
+    fn mgr() -> RemoteConnectionManager {
+        RemoteConnectionManager::new().expect("build manager")
+    }
+
+    fn alice_box() -> RemoteInfo {
+        RemoteInfo {
+            host: RemoteHost {
+                remote_type: RemoteType::Ssh,
+                user: "alice".to_string(),
+                host: "box".to_string(),
+                port: None,
+            },
+            remote_path: "/".to_string(),
+        }
+    }
+
+    #[test]
+    fn tramp_uri_strips_to_remote_path() {
+        let m = mgr();
+        let info = alice_box();
+        let converted = m
+            .convert_tramp_to_remote_uri("file:///ssh:alice@box:/home/alice/main.py", &info)
+            .expect("should convert");
+        assert_eq!(converted, "file:///home/alice/main.py");
+    }
+
+    #[test]
+    fn remote_uri_reassembled_to_tramp() {
+        let m = mgr();
+        let info = alice_box();
+        let converted = m
+            .convert_remote_to_tramp_uri("file:///home/alice/main.py", &info)
+            .expect("should convert");
+        assert_eq!(converted, "file:///ssh:alice@box:/home/alice/main.py");
+    }
+
+    #[test]
+    fn tramp_conversion_rejects_mismatched_host() {
+        let m = mgr();
+        let info = alice_box();
+        // URI embeds a different host — must not be rewritten.
+        let converted =
+            m.convert_tramp_to_remote_uri("file:///ssh:bob@other:/home/bob/x.py", &info);
+        assert!(converted.is_none());
+    }
+
+    #[test]
+    fn tramp_conversion_ignores_local_paths() {
+        let m = mgr();
+        let info = alice_box();
+        assert!(m
+            .convert_tramp_to_remote_uri("file:///home/alice/local.py", &info)
+            .is_none());
+        assert!(m
+            .convert_tramp_to_remote_uri("/not/a/uri", &info)
+            .is_none());
+    }
+
+    #[test]
+    fn json_transform_rewrites_nested_uris_for_remote() {
+        let m = mgr();
+        let info = alice_box();
+        let params = serde_json::json!({
+            "textDocument": { "uri": "file:///ssh:alice@box:/home/alice/a.py" },
+            "position": { "line": 1, "character": 2 },
+            "context": {
+                "includeDeclaration": true,
+                "relatedUris": [
+                    "file:///ssh:alice@box:/home/alice/b.py"
+                ]
+            }
+        });
+        let transformed = m
+            .transform_json_paths_for_remote(params, &info)
+            .expect("transform");
+        assert_eq!(
+            transformed["textDocument"]["uri"],
+            "file:///home/alice/a.py"
+        );
+        // Nested uri-bearing keys should also be rewritten.
+        // The walker targets keys named "uri" or ending in "Uri"; keys inside
+        // array values are still visited recursively.
+        let related = &transformed["context"]["relatedUris"][0];
+        // "relatedUris" ends with "Uri" so the array value itself gets passed
+        // through as a URI when it is a string; here it's an array, so the
+        // walker recurses into each string element leaving them unchanged
+        // unless the enclosing key matches. That's a known limitation — the
+        // test pins current behavior so future refactors surface the choice.
+        assert_eq!(related, "file:///ssh:alice@box:/home/alice/b.py");
+    }
+
+    #[test]
+    fn json_transform_rewrites_responses_back_to_tramp() {
+        let m = mgr();
+        let info = alice_box();
+        let response_result = serde_json::json!([
+            { "uri": "file:///home/alice/a.py", "range": {"start":{"line":0,"character":0}} },
+            { "uri": "file:///home/alice/b.py", "range": {"start":{"line":1,"character":1}} }
+        ]);
+        let transformed = m
+            .transform_json_paths_from_remote(response_result, &info)
+            .expect("transform back");
+        assert_eq!(
+            transformed[0]["uri"],
+            "file:///ssh:alice@box:/home/alice/a.py"
+        );
+        assert_eq!(
+            transformed[1]["uri"],
+            "file:///ssh:alice@box:/home/alice/b.py"
+        );
+    }
+
+    #[test]
+    fn extract_path_reads_text_document_uri() {
+        let m = mgr();
+        let params = serde_json::json!({
+            "textDocument": { "uri": "/ssh:alice@box:/home/alice/x.py" },
+            "position": {"line": 0, "character": 0}
+        });
+        let extracted = m.extract_uri_from_params(&params);
+        assert_eq!(extracted.as_deref(), Some("/ssh:alice@box:/home/alice/x.py"));
+    }
+}
+
+impl futures::AsyncWrite for SshRpcStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.writer).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.writer).poll_flush(cx)
+    }
+
+    fn poll_close(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.writer).poll_close(cx)
+    }
+}

--- a/src/remote/router.rs
+++ b/src/remote/router.rs
@@ -185,9 +185,37 @@ impl RemoteConnectionManager {
 
         match transformed_message {
             Message::Request(request) => {
+                let method = request.method.clone();
                 let response = client.send_request(request).await?;
+                let result_preview = response
+                    .result
+                    .as_ref()
+                    .map(|v| {
+                        let s = v.to_string();
+                        s[..s.len().min(256)].to_string()
+                    })
+                    .unwrap_or_else(|| "<none>".into());
+                debug!(
+                    "remote response before transform method={} id={:?} error={:?} result_preview={}",
+                    method,
+                    response.id,
+                    response.error.as_ref().map(|e| &e.message),
+                    result_preview
+                );
                 // 转换响应中的路径：将远程路径转换回TRAMP路径
                 let transformed_response = self.transform_response_paths_from_remote(response, &remote_info)?;
+                let after_preview = transformed_response
+                    .result
+                    .as_ref()
+                    .map(|v| {
+                        let s = v.to_string();
+                        s[..s.len().min(256)].to_string()
+                    })
+                    .unwrap_or_else(|| "<none>".into());
+                debug!(
+                    "remote response after transform method={} id={:?} result_preview={}",
+                    method, transformed_response.id, after_preview
+                );
                 Ok(Some(Message::Response(transformed_response)))
             }
             Message::Notification(notification) => {

--- a/src/remote/router.rs
+++ b/src/remote/router.rs
@@ -12,7 +12,6 @@ use super::{
     detector::{RemoteDetector, RemoteInfo, RemotePathInfo},
     rpc::RpcClient,
     ssh::{SshConnection, SshConnectionOptions},
-    RemoteType,
 };
 use crate::msg::{Message, Response};
 
@@ -119,19 +118,16 @@ impl RemoteConnectionManager {
         Ok(None)
     }
 
-    /// 处理远程消息
-    async fn handle_remote_message(&self, message: Message, remote_info: RemoteInfo) -> Result<Option<Message>> {
-        match remote_info.host.remote_type {
-            RemoteType::Ssh => {
-                // SSH类型使用RPC客户端
-                let client = self.get_or_create_rpc_client(&remote_info).await?;
-                self.handle_message_via_rpc(message, client, remote_info).await
-            }
-            RemoteType::Rpc => {
-                // 直接RPC连接（暂未实现）
-                Err(anyhow!("Direct RPC connections not yet implemented"))
-            }
-        }
+    /// 处理远程消息。`/ssh:` 和 `/rpc:` 前缀都走同一套 SSH 传输 — TRAMP
+    /// 方法名只是 Emacs 侧的约定,对我们而言底层都是 `ssh <host> …`。
+    async fn handle_remote_message(
+        &self,
+        message: Message,
+        remote_info: RemoteInfo,
+    ) -> Result<Option<Message>> {
+        let _ = remote_info.host.remote_type; // variant kept for future diversification
+        let client = self.get_or_create_rpc_client(&remote_info).await?;
+        self.handle_message_via_rpc(message, client, remote_info).await
     }
 
     /// 通过RPC处理消息

--- a/src/remote/router.rs
+++ b/src/remote/router.rs
@@ -498,13 +498,7 @@ impl RemoteConnectionManager {
         use deploy::{check_remote_binary, RemoteBinaryStatus, EXPECTED_VERSION};
 
         let fallback_path = crate::config::remote_binary_path();
-
-        let ssh_connections = self.ssh_connections.lock().await;
-        let conn = ssh_connections
-            .get(connection_key)
-            .ok_or_else(|| anyhow!("no SSH connection for {connection_key}"))?
-            .clone();
-        drop(ssh_connections);
+        let conn = self.ssh_for_key(connection_key).await?;
 
         let to_status = |s: RemoteBinaryStatus| match s {
             RemoteBinaryStatus::VersionMatch => crate::lsp_ext::RemoteBinaryLocationStatus {
@@ -571,13 +565,7 @@ impl RemoteConnectionManager {
     /// notifications.  Returns the binary command/path to use on success.
     pub async fn deploy_for_key(&self, connection_key: &str) -> Result<String> {
         let fallback_path = crate::config::remote_binary_path();
-
-        let ssh_connections = self.ssh_connections.lock().await;
-        let conn = ssh_connections
-            .get(connection_key)
-            .ok_or_else(|| anyhow!("no SSH connection for {connection_key}"))?
-            .clone();
-        drop(ssh_connections);
+        let conn = self.ssh_for_key(connection_key).await?;
 
         let sink = self.result_sink.lock().clone();
         let key = connection_key.to_string();
@@ -598,6 +586,52 @@ impl RemoteConnectionManager {
         };
 
         deploy::deploy_with_progress(conn.as_ref(), fallback_path, &send_progress).await
+    }
+
+    /// Return the SSH connection for `connection_key`, establishing a new one
+    /// if none exists yet.
+    ///
+    /// `connection_key` has the form `[user@]host[:port]` produced by
+    /// [`RemoteHost::connection_key`].  We parse it back to a [`RemoteHost`]
+    /// and delegate to [`get_or_create_ssh_connection`].
+    async fn ssh_for_key(&self, connection_key: &str) -> Result<Arc<SshConnection>> {
+        // Fast path: connection already exists.
+        {
+            let connections = self.ssh_connections.lock().await;
+            if let Some(conn) = connections.get(connection_key) {
+                return Ok(conn.clone());
+            }
+        }
+
+        // Parse "[user@]host[:port]" back into a RemoteHost.
+        let (user_host, port) = match connection_key.rsplit_once(':') {
+            Some((uh, p)) => {
+                if let Ok(port) = p.parse::<u16>() {
+                    (uh, Some(port))
+                } else {
+                    // The colon was part of an IPv6 address or similar; treat
+                    // the whole string as host with no port.
+                    (connection_key, None)
+                }
+            }
+            None => (connection_key, None),
+        };
+        let (user, host) = match user_host.split_once('@') {
+            Some((u, h)) => (u.to_string(), h.to_string()),
+            None => (String::new(), user_host.to_string()),
+        };
+
+        let remote_info = RemoteInfo {
+            host: super::RemoteHost {
+                remote_type: RemoteType::Ssh,
+                user,
+                host,
+                port,
+            },
+            remote_path: String::new(),
+        };
+
+        self.get_or_create_ssh_connection(&remote_info).await
     }
 
     /// Close all active SSH connections and RPC clients.

--- a/src/remote/router.rs
+++ b/src/remote/router.rs
@@ -14,9 +14,10 @@ use super::{
     ssh::{SshConnection, SshConnectionOptions},
     RemoteType,
 };
+use crate::msg::Notification;
 use crate::msg::{Message, Response};
 
-/// 远程连接管理器
+/// Manages SSH connections and RPC clients for remote LSP development.
 pub struct RemoteConnectionManager {
     detector: RemoteDetector,
     ssh_connections: Arc<Mutex<HashMap<String, Arc<SshConnection>>>>,
@@ -44,13 +45,13 @@ impl RemoteConnectionManager {
         *self.result_sink.lock() = Some(sink);
     }
 
-    /// 检查是否为远程路径
+    /// Returns `true` if `path` is a recognised remote (TRAMP) path.
     #[allow(dead_code)]
     pub fn is_remote_path(&self, path: &str) -> bool {
         self.detector.is_remote_path(path)
     }
 
-    /// 获取或创建SSH连接
+    /// Returns an existing SSH connection for `remote_info` or opens a new one.
     async fn get_or_create_ssh_connection(
         &self,
         remote_info: &RemoteInfo,
@@ -63,7 +64,6 @@ impl RemoteConnectionManager {
             return Ok(connection.clone());
         }
 
-        // 创建新的SSH连接
         let options =
             SshConnectionOptions::new(remote_info.host.host.clone(), remote_info.host.user.clone());
 
@@ -80,7 +80,7 @@ impl RemoteConnectionManager {
         Ok(connection)
     }
 
-    /// 获取或创建RPC客户端
+    /// Returns an existing RPC client for `remote_info` or creates a new one.
     async fn get_or_create_rpc_client(&self, remote_info: &RemoteInfo) -> Result<Arc<RpcClient>> {
         let connection_key = remote_info.host.connection_key();
 
@@ -105,21 +105,36 @@ impl RemoteConnectionManager {
             ssh.remove(&connection_key);
         }
 
-        // 通过SSH启动远程LSP代理并创建RPC客户端
         let ssh_connection = self.get_or_create_ssh_connection(remote_info).await?;
 
-        // 在启动远程进程前,先确保远端 binary 存在且版本匹配,否则 scp 过去
-        let remote_lsp_path = crate::config::remote_binary_path();
-        deploy::ensure_remote_binary(ssh_connection.as_ref(), remote_lsp_path)
-            .await
-            .map_err(|e| anyhow!("auto-deploy failed for {connection_key}: {e}"))?;
+        // Before launching the remote process, verify that a compatible binary
+        // is available.  If not, notify Emacs so the user can trigger a manual
+        // deploy and abort this connection attempt.
+        let fallback_path = crate::config::remote_binary_path();
+        let binary_cmd = match deploy::check_binary_available(
+            ssh_connection.as_ref(),
+            fallback_path,
+        )
+        .await
+        {
+            Ok(cmd) => cmd,
+            Err(e) => {
+                warn!("remote binary unavailable for {connection_key}: {e}");
+                self.send_deploy_needed_notification(
+                    &connection_key,
+                    &e.to_string(),
+                    fallback_path,
+                );
+                return Err(anyhow!(
+                    "remote binary unavailable for {connection_key}: {e}"
+                ));
+            }
+        };
 
-        // 启动远程LSP代理进程
         let lsp_process = ssh_connection
-            .start_remote_lsp_proxy(remote_lsp_path)
+            .start_remote_lsp_proxy(&binary_cmd)
             .await?;
 
-        // 创建RPC客户端，使用SSH隧道
         let stream = SshRpcStream::from_child_stdio(lsp_process.stdin, lsp_process.stdout);
 
         // Set up the unsolicited-message bridge: the RpcClient pushes raw
@@ -158,7 +173,8 @@ impl RemoteConnectionManager {
         Ok(client)
     }
 
-    /// 路由消息到适当的后端
+    /// Route `message` to the remote backend when its URI is a TRAMP path,
+    /// or return `None` to indicate that local handling should apply.
     pub async fn route_message(&self, message: Message) -> Result<Option<Message>> {
         let path = self.extract_path_from_message(&message);
 
@@ -172,18 +188,19 @@ impl RemoteConnectionManager {
                     return self.handle_remote_message(message, remote_info).await;
                 }
                 RemotePathInfo::Local(_) => {
-                    // 本地路径，返回None表示由本地处理
                     return Ok(None);
                 }
             }
         }
 
-        // 没有路径信息或无法解析，本地处理
         Ok(None)
     }
 
-    /// 处理远程消息。`/ssh:` 和 `/rpc:` 前缀都走同一套 SSH 传输 — TRAMP
-    /// 方法名只是 Emacs 侧的约定,对我们而言底层都是 `ssh <host> …`。
+    /// Dispatch `message` to the appropriate remote transport.
+    ///
+    /// Both `/ssh:` and `/rpc:` TRAMP methods use the same SSH tunnel — the
+    /// method prefix is purely an Emacs convention; the transport is always
+    /// `ssh <host> …`.
     async fn handle_remote_message(
         &self,
         message: Message,
@@ -195,14 +212,13 @@ impl RemoteConnectionManager {
             .await
     }
 
-    /// 通过RPC处理消息
+    /// Forward `message` through `client`, rewriting paths in both directions.
     async fn handle_message_via_rpc(
         &self,
         message: Message,
         client: Arc<RpcClient>,
         remote_info: RemoteInfo,
     ) -> Result<Option<Message>> {
-        // 转换路径：将TRAMP路径转换为远程路径
         let transformed_message = self.transform_paths_for_remote(message, &remote_info)?;
 
         match transformed_message {
@@ -224,7 +240,7 @@ impl RemoteConnectionManager {
                     response.error.as_ref().map(|e| &e.message),
                     result_preview
                 );
-                // 转换响应中的路径：将远程路径转换回TRAMP路径
+                // Rewrite remote paths in the response back to TRAMP form.
                 let transformed_response =
                     self.transform_response_paths_from_remote(response, &remote_info)?;
                 let after_preview = transformed_response
@@ -243,7 +259,7 @@ impl RemoteConnectionManager {
             }
             Message::Notification(notification) => {
                 client.send_notification(notification)?;
-                Ok(None) // 通知不需要响应
+                Ok(None) // Notifications have no response.
             }
             Message::Response(_) => {
                 warn!("Received response message for routing, this should not happen");
@@ -252,29 +268,25 @@ impl RemoteConnectionManager {
         }
     }
 
-    /// 从消息中提取文件路径
+    /// Extract the primary URI from `message`, if present.
     fn extract_path_from_message(&self, message: &Message) -> Option<String> {
         match message {
             Message::Request(req) => {
-                // 从请求参数中提取URI
                 if let Some(uri) = &req.params.uri {
                     Some(uri.clone())
                 } else {
-                    // 尝试从params中提取textDocument.uri
                     self.extract_uri_from_params(&req.params.params)
                 }
             }
             Message::Notification(notif) => {
-                // 从通知参数中提取URI
                 self.extract_uri_from_params(&notif.params.params)
             }
             _ => None,
         }
     }
 
-    /// 从JSON参数中提取URI
+    /// Extract a URI from raw LSP JSON params, checking `textDocument.uri` then `uri`.
     fn extract_uri_from_params(&self, params: &serde_json::Value) -> Option<String> {
-        // 尝试多种路径提取方式
         if let Some(text_doc) = params.get("textDocument") {
             if let Some(uri) = text_doc.get("uri") {
                 return uri.as_str().map(|s| s.to_string());
@@ -288,7 +300,7 @@ impl RemoteConnectionManager {
         None
     }
 
-    /// 转换消息中的路径以适应远程执行
+    /// Rewrite TRAMP URIs in `message` to bare remote paths for the remote LSP.
     fn transform_paths_for_remote(
         &self,
         message: Message,
@@ -296,14 +308,12 @@ impl RemoteConnectionManager {
     ) -> Result<Message> {
         match message {
             Message::Request(mut req) => {
-                // 转换URI路径
                 if let Some(uri) = &req.params.uri {
                     if let Some(remote_uri) = self.convert_tramp_to_remote_uri(uri, remote_info) {
                         req.params.uri = Some(remote_uri);
                     }
                 }
 
-                // 转换params中的路径
                 req.params.params =
                     self.transform_json_paths_for_remote(req.params.params, remote_info)?;
 
@@ -318,7 +328,7 @@ impl RemoteConnectionManager {
         }
     }
 
-    /// 转换响应中的路径
+    /// Rewrite remote paths in `response` back to TRAMP form for Emacs.
     fn transform_response_paths_from_remote(
         &self,
         mut response: Response,
@@ -330,7 +340,7 @@ impl RemoteConnectionManager {
         Ok(response)
     }
 
-    /// 转换JSON中的路径（远程 -> 本地）
+    /// Recursively rewrite TRAMP URIs in `value` to bare remote paths (outgoing).
     fn transform_json_paths_for_remote(
         &self,
         mut value: serde_json::Value,
@@ -362,7 +372,7 @@ impl RemoteConnectionManager {
         Ok(value)
     }
 
-    /// 转换JSON中的路径（本地 -> 远程）
+    /// Recursively rewrite bare remote paths in `value` to TRAMP URIs (incoming).
     fn transform_json_paths_from_remote(
         &self,
         mut value: serde_json::Value,
@@ -394,13 +404,12 @@ impl RemoteConnectionManager {
         Ok(value)
     }
 
-    /// 将TRAMP URI转换为远程URI
+    /// Convert a TRAMP `file://` URI to a bare remote path URI, or return `None`
+    /// if the URI does not belong to `remote_info`'s host.
     fn convert_tramp_to_remote_uri(&self, uri: &str, remote_info: &RemoteInfo) -> Option<String> {
         if let Some(path) = uri.strip_prefix("file://") {
-            // 移除 "file://" 前缀
             if let Some(remote_info_from_path) = self.detector.extract_remote_info(path) {
                 if remote_info_from_path.host == remote_info.host {
-                    // 转换为远程文件URI
                     return Some(format!("file://{}", remote_info_from_path.remote_path));
                 }
             }
@@ -408,10 +417,9 @@ impl RemoteConnectionManager {
         None
     }
 
-    /// 将远程URI转换为TRAMP URI
+    /// Convert a bare remote path `file://` URI back to a TRAMP URI, or return `None`.
     fn convert_remote_to_tramp_uri(&self, uri: &str, remote_info: &RemoteInfo) -> Option<String> {
         if let Some(remote_path) = uri.strip_prefix("file://") {
-            // 移除 "file://" 前缀
             let tramp_path = self.detector.remote_to_local_path(&RemoteInfo {
                 host: remote_info.host.clone(),
                 remote_path: remote_path.to_string(),
@@ -427,32 +435,49 @@ impl RemoteConnectionManager {
         let ssh_conns = self.ssh_connections.lock().await;
         let mut infos = Vec::new();
         for (key, client) in clients.iter() {
-            // Probe deployment status via the SSH connection for this key.
-            let remote_path = crate::config::remote_binary_path();
-            let (deploy_status, remote_version) = match ssh_conns.get(key) {
-                Some(ssh) => match deploy::check_remote_binary(ssh, remote_path).await {
-                    Ok(deploy::RemoteBinaryStatus::VersionMatch) => {
-                        ("deployed".to_string(), Some(deploy::EXPECTED_VERSION.to_string()))
+            // Probe deployment status — apply the same global-first priority.
+            let fallback_path = crate::config::remote_binary_path();
+            let (binary_path, deploy_status, remote_version) = match ssh_conns.get(key) {
+                Some(ssh) => {
+                    // Check global command first.
+                    match deploy::check_remote_binary(ssh, "emacs-lsp-proxy").await {
+                        Ok(deploy::RemoteBinaryStatus::VersionMatch) => (
+                            "emacs-lsp-proxy".to_string(),
+                            "deployed".to_string(),
+                            Some(deploy::EXPECTED_VERSION.to_string()),
+                        ),
+                        _ => {
+                            // Fall back to fixed path.
+                            match deploy::check_remote_binary(ssh, fallback_path).await {
+                                Ok(deploy::RemoteBinaryStatus::VersionMatch) => (
+                                    fallback_path.to_string(),
+                                    "deployed".to_string(),
+                                    Some(deploy::EXPECTED_VERSION.to_string()),
+                                ),
+                                Ok(deploy::RemoteBinaryStatus::VersionMismatch { remote }) => (
+                                    fallback_path.to_string(),
+                                    "version_mismatch".to_string(),
+                                    Some(remote),
+                                ),
+                                Ok(deploy::RemoteBinaryStatus::Missing) => {
+                                    (fallback_path.to_string(), "missing".to_string(), None)
+                                }
+                                Err(e) => {
+                                    warn!("failed to probe remote binary for {key}: {e}");
+                                    (fallback_path.to_string(), "unknown".to_string(), None)
+                                }
+                            }
+                        }
                     }
-                    Ok(deploy::RemoteBinaryStatus::VersionMismatch { remote }) => {
-                        ("version_mismatch".to_string(), Some(remote))
-                    }
-                    Ok(deploy::RemoteBinaryStatus::Missing) => {
-                        ("missing".to_string(), None)
-                    }
-                    Err(e) => {
-                        warn!("failed to probe remote binary for {key}: {e}");
-                        ("unknown".to_string(), None)
-                    }
-                },
-                None => ("unknown".to_string(), None),
+                }
+                None => (fallback_path.to_string(), "unknown".to_string(), None),
             };
 
             infos.push(crate::lsp_ext::RemoteClientInfo {
                 connection_key: key.clone(),
                 remote_type: "rpc".to_string(),
                 is_alive: !client.is_dead(),
-                binary_path: remote_path.to_string(),
+                binary_path,
                 local_version: deploy::EXPECTED_VERSION.to_string(),
                 remote_version,
                 deploy_status,
@@ -464,14 +489,123 @@ impl RemoteConnectionManager {
         }
     }
 
-    /// 清理资源
+    /// Probe the global command and deploy path on the remote host without
+    /// uploading anything.  Returns a structured result for Emacs to display.
+    pub async fn check_binary_status(
+        &self,
+        connection_key: &str,
+    ) -> Result<crate::lsp_ext::CheckRemoteBinaryResult> {
+        use deploy::{check_remote_binary, RemoteBinaryStatus, EXPECTED_VERSION};
+
+        let fallback_path = crate::config::remote_binary_path();
+
+        let ssh_connections = self.ssh_connections.lock().await;
+        let conn = ssh_connections
+            .get(connection_key)
+            .ok_or_else(|| anyhow!("no SSH connection for {connection_key}"))?
+            .clone();
+        drop(ssh_connections);
+
+        let to_status = |s: RemoteBinaryStatus| match s {
+            RemoteBinaryStatus::VersionMatch => crate::lsp_ext::RemoteBinaryLocationStatus {
+                status: "match".to_string(),
+                version: Some(EXPECTED_VERSION.to_string()),
+            },
+            RemoteBinaryStatus::VersionMismatch { remote } => {
+                crate::lsp_ext::RemoteBinaryLocationStatus {
+                    status: "version_mismatch".to_string(),
+                    version: Some(remote),
+                }
+            }
+            RemoteBinaryStatus::Missing => crate::lsp_ext::RemoteBinaryLocationStatus {
+                status: "missing".to_string(),
+                version: None,
+            },
+        };
+
+        let global_raw = check_remote_binary(conn.as_ref(), "emacs-lsp-proxy").await?;
+        let path_raw = check_remote_binary(conn.as_ref(), fallback_path).await?;
+
+        let available_binary = match (&global_raw, &path_raw) {
+            (RemoteBinaryStatus::VersionMatch, _) => Some("emacs-lsp-proxy".to_string()),
+            (_, RemoteBinaryStatus::VersionMatch) => Some(fallback_path.to_string()),
+            _ => None,
+        };
+
+        Ok(crate::lsp_ext::CheckRemoteBinaryResult {
+            global: to_status(global_raw),
+            path: to_status(path_raw),
+            available_binary,
+            local_version: EXPECTED_VERSION.to_string(),
+            deploy_path: fallback_path.to_string(),
+        })
+    }
+
+    /// Send an `emacs/remoteDeployNeeded` notification to Emacs via the result
+    /// sink, informing the user that they must run a manual deploy.
+    fn send_deploy_needed_notification(
+        &self,
+        connection_key: &str,
+        reason: &str,
+        deploy_path: &str,
+    ) {
+        let params = crate::lsp_ext::RemoteDeployNeededParams {
+            connection_key: connection_key.to_string(),
+            reason: reason.to_string(),
+            remote_version: None,
+            local_version: deploy::EXPECTED_VERSION.to_string(),
+            deploy_path: deploy_path.to_string(),
+        };
+        use lsp_types::notification::Notification as _;
+        let notif = Message::Notification(Notification::new(
+            crate::lsp_ext::RemoteDeployNeeded::METHOD.to_string(),
+            params,
+        ));
+        if let Some(sink) = self.result_sink.lock().as_ref() {
+            sink.send(notif).ok();
+        }
+    }
+
+    /// Deploy the local binary to the remote host identified by `connection_key`,
+    /// streaming progress back to Emacs via `emacs/remoteDeployProgress`
+    /// notifications.  Returns the binary command/path to use on success.
+    pub async fn deploy_for_key(&self, connection_key: &str) -> Result<String> {
+        let fallback_path = crate::config::remote_binary_path();
+
+        let ssh_connections = self.ssh_connections.lock().await;
+        let conn = ssh_connections
+            .get(connection_key)
+            .ok_or_else(|| anyhow!("no SSH connection for {connection_key}"))?
+            .clone();
+        drop(ssh_connections);
+
+        let sink = self.result_sink.lock().clone();
+        let key = connection_key.to_string();
+
+        let send_progress = move |msg: String| {
+            let params = crate::lsp_ext::RemoteDeployProgressParams {
+                connection_key: key.clone(),
+                message: msg,
+            };
+            use lsp_types::notification::Notification as _;
+            let notif = Message::Notification(Notification::new(
+                crate::lsp_ext::RemoteDeployProgress::METHOD.to_string(),
+                params,
+            ));
+            if let Some(s) = sink.as_ref() {
+                s.send(notif).ok();
+            }
+        };
+
+        deploy::deploy_with_progress(conn.as_ref(), fallback_path, &send_progress).await
+    }
+
+    /// Close all active SSH connections and RPC clients.
     #[allow(dead_code)]
     pub async fn cleanup(&self) {
-        // 清理SSH连接
         let mut connections = self.ssh_connections.lock().await;
         connections.clear();
 
-        // 清理RPC客户端
         let mut clients = self.rpc_clients.lock().await;
         clients.clear();
 
@@ -554,11 +688,12 @@ fn local_file_uri_to_tramp(uri: &str, remote_info: &RemoteInfo) -> Option<String
     Some(format!("file://{tramp}"))
 }
 
-/// SSH RPC 流适配器 — 把子进程的 stdin/stdout 组合成一个同时实现
-/// `futures::AsyncRead` 和 `futures::AsyncWrite` 的双向流。
+/// Bidirectional stream adapter wrapping a child process's stdin/stdout.
 ///
-/// 内部通过 `tokio_util::compat::Compat` 把 tokio 的 AsyncRead/AsyncWrite
-/// 转换成 futures 版本,避免自己手写 `poll_*` 里的 ReadBuf / wake 细节。
+/// Combines the two halves into a single type that implements both
+/// `futures::AsyncRead` and `futures::AsyncWrite`, using
+/// `tokio_util::compat::Compat` to bridge tokio's async I/O traits to the
+/// futures versions expected by the RPC framing layer.
 pub struct SshRpcStream {
     reader: Compat<tokio::process::ChildStdout>,
     writer: Compat<tokio::process::ChildStdin>,

--- a/src/remote/router.rs
+++ b/src/remote/router.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use log::{debug, info, warn};
 use std::collections::HashMap;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::task::Poll;
 use tokio::sync::Mutex;
 use tokio_util::compat::{Compat, TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
@@ -140,7 +140,7 @@ impl RemoteConnectionManager {
             .start_remote_lsp_proxy(&binary_cmd)
             .await?;
 
-        let stream = SshRpcStream::from_child_stdio(
+        let (stream, process_handle) = SshRpcStream::from_child_stdio(
             lsp_process.stdin,
             lsp_process.stdout,
             lsp_process.process,
@@ -152,7 +152,11 @@ impl RemoteConnectionManager {
         // them to the Controller's result sink.
         let (unsolicited_tx, mut unsolicited_rx) =
             tokio::sync::mpsc::unbounded_channel::<Message>();
-        let client = Arc::new(RpcClient::new(stream, Some(unsolicited_tx))?);
+        let client = Arc::new(RpcClient::new_with_transport_killer(
+            stream,
+            Some(unsolicited_tx),
+            Some(Arc::new(move || process_handle.kill_sync())),
+        )?);
 
         let sink_snapshot = self.result_sink.lock().clone();
         match sink_snapshot {
@@ -643,13 +647,40 @@ impl RemoteConnectionManager {
         self.get_or_create_ssh_connection(&remote_info).await
     }
 
+    /// Synchronous best-effort kill of all remote processes.
+    ///
+    /// Called just before `process::exit()` where async code cannot run.
+    /// Rather than clearing the Arc maps (which requires the refcount to be 1
+    /// and may fail if in-flight tasks hold clones), explicitly kill every SSH
+    /// slave process that carries a remote RPC stream, then shut down the SSH
+    /// ControlMaster.
+    pub fn kill_all_sync(&self) {
+        if let Ok(clients) = self.rpc_clients.try_lock() {
+            for client in clients.values() {
+                client.kill_transport_sync();
+            }
+        }
+        if let Ok(connections) = self.ssh_connections.try_lock() {
+            for conn in connections.values() {
+                conn.kill_master_sync();
+            }
+        }
+        info!("kill_all_sync: remote RPC transports and ControlMaster processes signalled");
+    }
+
     /// Close all active connections in the correct order:
     /// RPC clients first (EOF to remote process), then SSH connections (ControlMaster).
     pub async fn cleanup(&self) {
-        // 1. Drop RPC clients — this drops SshRpcStream which kill_on_drop's
-        //    the local SSH slave process, sending EOF/SIGHUP to the remote
-        //    `emacs-lsp-proxy --remote-server`.
-        self.rpc_clients.lock().await.clear();
+        // 1. Kill RPC transports first.  This terminates the local SSH slave
+        //    process carrying the remote `emacs-lsp-proxy --remote-server`
+        //    before the ControlMaster is torn down.
+        {
+            let mut clients = self.rpc_clients.lock().await;
+            for client in clients.values() {
+                client.kill_transport_sync();
+            }
+            clients.clear();
+        }
 
         // 2. Drop SSH connections — kills the ControlMaster after children
         //    have already been signalled.
@@ -744,11 +775,26 @@ pub struct SshRpcStream {
     reader: Compat<tokio::process::ChildStdout>,
     writer: Compat<tokio::process::ChildStdin>,
     /// The local SSH slave process that carries the tunnel.  Kept here so its
-    /// lifetime matches the stream: when `SshRpcStream` is dropped (i.e. when
-    /// the `RpcClient` is dropped), the process is automatically killed via
-    /// `kill_on_drop`.  This ensures the remote `emacs-lsp-proxy --remote-server`
-    /// loses its connection and exits before the SSH ControlMaster is torn down.
-    _process: tokio::process::Child,
+    /// lifetime matches the stream.  A clone of the handle is also stored on
+    /// the `RpcClient` so shutdown paths that call `process::exit()` can kill
+    /// the process synchronously without relying on Drop.
+    _process: SshRpcProcessHandle,
+}
+
+#[derive(Clone)]
+pub struct SshRpcProcessHandle {
+    process: Arc<StdMutex<Option<tokio::process::Child>>>,
+}
+
+impl SshRpcProcessHandle {
+    pub fn kill_sync(&self) {
+        if let Ok(mut guard) = self.process.lock() {
+            if let Some(child) = guard.as_mut() {
+                let _ = child.start_kill();
+            }
+            *guard = None;
+        }
+    }
 }
 
 impl SshRpcStream {
@@ -756,12 +802,16 @@ impl SshRpcStream {
         stdin: tokio::process::ChildStdin,
         stdout: tokio::process::ChildStdout,
         process: tokio::process::Child,
-    ) -> Self {
-        Self {
+    ) -> (Self, SshRpcProcessHandle) {
+        let process = SshRpcProcessHandle {
+            process: Arc::new(StdMutex::new(Some(process))),
+        };
+        let stream = Self {
             reader: stdout.compat(),
             writer: stdin.compat_write(),
-            _process: process,
-        }
+            _process: process.clone(),
+        };
+        (stream, process)
     }
 }
 

--- a/src/remote/router.rs
+++ b/src/remote/router.rs
@@ -85,7 +85,23 @@ impl RemoteConnectionManager {
         let mut clients = self.rpc_clients.lock().await;
 
         if let Some(client) = clients.get(&connection_key) {
-            return Ok(client.clone());
+            if !client.is_dead() {
+                return Ok(client.clone());
+            }
+            // The background communication loop exited — the SSH tunnel or
+            // remote process died. Evict the zombie so the code below spawns
+            // a fresh tunnel instead of handing back a guaranteed-to-fail
+            // client for the rest of the session.
+            warn!(
+                "RPC client for {} is dead; evicting and reconnecting",
+                connection_key
+            );
+            clients.remove(&connection_key);
+            // A dead RPC client typically means the SSH child exited; the
+            // master socket may also have gone stale. Force a fresh SSH
+            // connection too so we don't reuse a broken ControlPath.
+            let mut ssh = self.ssh_connections.lock().await;
+            ssh.remove(&connection_key);
         }
 
         // 通过SSH启动远程LSP代理并创建RPC客户端

--- a/src/remote/router.rs
+++ b/src/remote/router.rs
@@ -1,5 +1,16 @@
 use anyhow::{anyhow, Result};
 use log::{debug, info, warn};
+
+/// Truncate `s` to at most `max_bytes` bytes, respecting UTF-8 character boundaries.
+fn truncate_preview(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    match s.char_indices().map(|(i, _)| i).take_while(|&i| i <= max_bytes).last() {
+        Some(i) if i < s.len() => &s[..i],
+        _ => &s[..max_bytes],
+    }
+}
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -239,7 +250,7 @@ impl RemoteConnectionManager {
                     .as_ref()
                     .map(|v| {
                         let s = v.to_string();
-                        s[..s.len().min(256)].to_string()
+                        truncate_preview(&s, 256).to_string()
                     })
                     .unwrap_or_else(|| "<none>".into());
                 debug!(
@@ -257,7 +268,7 @@ impl RemoteConnectionManager {
                     .as_ref()
                     .map(|v| {
                         let s = v.to_string();
-                        s[..s.len().min(256)].to_string()
+                        truncate_preview(&s, 256).to_string()
                     })
                     .unwrap_or_else(|| "<none>".into());
                 debug!(

--- a/src/remote/router.rs
+++ b/src/remote/router.rs
@@ -20,8 +20,13 @@ use crate::msg::{Message, Response};
 /// Manages SSH connections and RPC clients for remote LSP development.
 pub struct RemoteConnectionManager {
     detector: RemoteDetector,
-    ssh_connections: Arc<Mutex<HashMap<String, Arc<SshConnection>>>>,
+    // *** Drop order matters — Rust drops fields in declaration order. ***
+    // RPC clients must be dropped BEFORE SSH connections so that the remote
+    // process receives EOF on its stdin (graceful close via SshRpcStream /
+    // kill_on_drop) before the ControlMaster is torn down.  Reversing the
+    // order would kill the master first, leaving the child sessions in limbo.
     rpc_clients: Arc<Mutex<HashMap<String, Arc<RpcClient>>>>,
+    ssh_connections: Arc<Mutex<HashMap<String, Arc<SshConnection>>>>,
     /// Where path-corrected server-initiated messages get pushed. Set once
     /// by the Controller during startup; each new RpcClient spawns a bridge
     /// task that drains its unsolicited channel into this sink.
@@ -32,8 +37,8 @@ impl RemoteConnectionManager {
     pub fn new() -> Result<Self> {
         Ok(Self {
             detector: RemoteDetector::new()?,
-            ssh_connections: Arc::new(Mutex::new(HashMap::new())),
             rpc_clients: Arc::new(Mutex::new(HashMap::new())),
+            ssh_connections: Arc::new(Mutex::new(HashMap::new())),
             result_sink: Arc::new(parking_lot::Mutex::new(None)),
         })
     }
@@ -135,7 +140,11 @@ impl RemoteConnectionManager {
             .start_remote_lsp_proxy(&binary_cmd)
             .await?;
 
-        let stream = SshRpcStream::from_child_stdio(lsp_process.stdin, lsp_process.stdout);
+        let stream = SshRpcStream::from_child_stdio(
+            lsp_process.stdin,
+            lsp_process.stdout,
+            lsp_process.process,
+        );
 
         // Set up the unsolicited-message bridge: the RpcClient pushes raw
         // server-initiated messages into a per-client tokio channel, and we
@@ -634,14 +643,17 @@ impl RemoteConnectionManager {
         self.get_or_create_ssh_connection(&remote_info).await
     }
 
-    /// Close all active SSH connections and RPC clients.
-    #[allow(dead_code)]
+    /// Close all active connections in the correct order:
+    /// RPC clients first (EOF to remote process), then SSH connections (ControlMaster).
     pub async fn cleanup(&self) {
-        let mut connections = self.ssh_connections.lock().await;
-        connections.clear();
+        // 1. Drop RPC clients — this drops SshRpcStream which kill_on_drop's
+        //    the local SSH slave process, sending EOF/SIGHUP to the remote
+        //    `emacs-lsp-proxy --remote-server`.
+        self.rpc_clients.lock().await.clear();
 
-        let mut clients = self.rpc_clients.lock().await;
-        clients.clear();
+        // 2. Drop SSH connections — kills the ControlMaster after children
+        //    have already been signalled.
+        self.ssh_connections.lock().await.clear();
 
         info!("Remote connections cleaned up");
     }
@@ -731,16 +743,24 @@ fn local_file_uri_to_tramp(uri: &str, remote_info: &RemoteInfo) -> Option<String
 pub struct SshRpcStream {
     reader: Compat<tokio::process::ChildStdout>,
     writer: Compat<tokio::process::ChildStdin>,
+    /// The local SSH slave process that carries the tunnel.  Kept here so its
+    /// lifetime matches the stream: when `SshRpcStream` is dropped (i.e. when
+    /// the `RpcClient` is dropped), the process is automatically killed via
+    /// `kill_on_drop`.  This ensures the remote `emacs-lsp-proxy --remote-server`
+    /// loses its connection and exits before the SSH ControlMaster is torn down.
+    _process: tokio::process::Child,
 }
 
 impl SshRpcStream {
     pub fn from_child_stdio(
         stdin: tokio::process::ChildStdin,
         stdout: tokio::process::ChildStdout,
+        process: tokio::process::Child,
     ) -> Self {
         Self {
             reader: stdout.compat(),
             writer: stdin.compat_write(),
+            _process: process,
         }
     }
 }

--- a/src/remote/rpc.rs
+++ b/src/remote/rpc.rs
@@ -46,7 +46,7 @@ pub async fn read_envelope<S: AsyncRead + Unpin>(
     stream.read_exact(buffer).await?;
     let message_len = MessageLen::from_le_bytes(buffer.as_slice().try_into().unwrap());
     if message_len == 0 || message_len > MAX_MESSAGE_LEN {
-        return Err(anyhow!("Invalid envelope length: {}", message_len));
+        return Err(anyhow!("Invalid envelope length: {message_len}"));
     }
     buffer.resize(message_len as usize, 0);
     stream.read_exact(buffer).await?;
@@ -82,7 +82,7 @@ enum OutgoingCommand {
 /// RPC client that speaks Protobuf-framed Envelopes over a duplex byte stream.
 pub struct RpcClient {
     sender: UnboundedSender<OutgoingCommand>,
-    next_id: Arc<AtomicU32>,
+    _next_id: Arc<AtomicU32>,
     /// Set to true by the heartbeat task when it decides the far end is
     /// unresponsive (N consecutive ping misses). Checked by `is_dead()`.
     dead: Arc<AtomicBool>,
@@ -108,7 +108,7 @@ impl RpcClient {
         tokio::spawn(Self::heartbeat_loop(sender.clone(), dead.clone()));
         Ok(Self {
             sender,
-            next_id: Arc::new(AtomicU32::new(1)),
+            _next_id: Arc::new(AtomicU32::new(1)),
             dead,
         })
     }
@@ -159,20 +159,18 @@ impl RpcClient {
             match res {
                 Ok(Ok(Ok(_))) => {
                     if consecutive_misses > 0 {
-                        debug!("heartbeat: recovered after {} misses", consecutive_misses);
+                        debug!("heartbeat: recovered after {consecutive_misses} misses");
                     }
                     consecutive_misses = 0;
                 }
                 _ => {
                     consecutive_misses += 1;
                     warn!(
-                        "heartbeat: ping miss {}/{}",
-                        consecutive_misses, MAX_MISSED_HEARTBEATS
+                        "heartbeat: ping miss {consecutive_misses}/{MAX_MISSED_HEARTBEATS}"
                     );
                     if consecutive_misses >= MAX_MISSED_HEARTBEATS {
                         warn!(
-                            "heartbeat: {} consecutive misses, marking RPC client dead",
-                            MAX_MISSED_HEARTBEATS
+                            "heartbeat: {MAX_MISSED_HEARTBEATS} consecutive misses, marking RPC client dead"
                         );
                         dead.store(true, Ordering::Relaxed);
                         return;
@@ -186,10 +184,10 @@ impl RpcClient {
     /// - the background communication loop has exited (`sender.is_closed()`
     ///   — underlying transport died), or
     /// - the heartbeat task declared the far end unresponsive.
-    /// Cached clients that report `is_dead()` must be evicted and recreated
-    /// before the next request — otherwise every subsequent `send_request`
-    /// either fails instantly ("channel closed") or hangs until its 30s
-    /// timeout, repeatedly.
+    ///   Cached clients that report `is_dead()` must be evicted and recreated
+    ///   before the next request — otherwise every subsequent `send_request`
+    ///   either fails instantly ("channel closed") or hangs until its 30s
+    ///   timeout, repeatedly.
     pub fn is_dead(&self) -> bool {
         self.sender.is_closed() || self.dead.load(Ordering::Relaxed)
     }
@@ -212,8 +210,7 @@ impl RpcClient {
             }
             Err(_) => {
                 warn!(
-                    "RPC request timeout after 30s: method={} orig_id={:?}",
-                    method, orig_id
+                    "RPC request timeout after 30s: method={method} orig_id={orig_id:?}"
                 );
                 Err(anyhow!("RPC request timeout"))
             }
@@ -252,14 +249,13 @@ impl RpcClient {
                             let params_bytes = match serde_json::to_vec(&request.params) {
                                 Ok(b) => b,
                                 Err(e) => {
-                                    let _ = response_tx.send(Err(anyhow!("encode params: {}", e)));
+                                    let _ = response_tx.send(Err(anyhow!("encode params: {e}")));
                                     continue;
                                 }
                             };
                             let method_for_log = request.method.clone();
                             debug!(
-                                "RPC send request env_id={} method={} orig_id={:?}",
-                                envelope_id, method_for_log, original_id
+                                "RPC send request env_id={envelope_id} method={method_for_log} orig_id={original_id:?}"
                             );
                             let envelope = Envelope {
                                 id: Some(envelope_id),
@@ -270,7 +266,7 @@ impl RpcClient {
                                 })),
                             };
                             if let Err(e) = write_envelope(&mut stream, &mut buffer, envelope).await {
-                                error!("Failed to write request envelope: {}", e);
+                                error!("Failed to write request envelope: {e}");
                                 let _ = response_tx.send(Err(e));
                                 break;
                             }
@@ -280,7 +276,7 @@ impl RpcClient {
                             let params_bytes = match serde_json::to_vec(&notif.params) {
                                 Ok(b) => b,
                                 Err(e) => {
-                                    warn!("Failed to encode notification params: {}", e);
+                                    warn!("Failed to encode notification params: {e}");
                                     continue;
                                 }
                             };
@@ -293,7 +289,7 @@ impl RpcClient {
                                 })),
                             };
                             if let Err(e) = write_envelope(&mut stream, &mut buffer, envelope).await {
-                                error!("Failed to write notification envelope: {}", e);
+                                error!("Failed to write notification envelope: {e}");
                                 break;
                             }
                         }
@@ -321,12 +317,12 @@ impl RpcClient {
                                                 &bytes[..bytes.len().min(512)],
                                             )
                                             .into_owned();
-                                            debug!("RPC recv result preview: {}", preview);
+                                            debug!("RPC recv result preview: {preview}");
                                         }
                                         let response = decode_response(orig_id, resp);
                                         let _ = tx.send(response);
                                     } else {
-                                        debug!("Unmatched response envelope id={}", env_id);
+                                        debug!("Unmatched response envelope id={env_id}");
                                     }
                                 } else {
                                     debug!("Response envelope missing responding_to");
@@ -335,13 +331,13 @@ impl RpcClient {
                             Some(envelope::Payload::Notification(notif)) => {
                                 match decode_notification(notif) {
                                     Ok(msg) => forward_unsolicited(&unsolicited, msg),
-                                    Err(e) => warn!("bad server notification: {}", e),
+                                    Err(e) => warn!("bad server notification: {e}"),
                                 }
                             }
                             Some(envelope::Payload::Request(req)) => {
                                 match decode_server_request(envelope.id, req) {
                                     Ok(msg) => forward_unsolicited(&unsolicited, msg),
-                                    Err(e) => warn!("bad server request: {}", e),
+                                    Err(e) => warn!("bad server request: {e}"),
                                 }
                             }
                             None => {
@@ -349,7 +345,7 @@ impl RpcClient {
                             }
                         },
                         Err(e) => {
-                            error!("RPC read error: {}", e);
+                            error!("RPC read error: {e}");
                             break;
                         }
                     }
@@ -362,8 +358,8 @@ impl RpcClient {
         }
     }
 
-    pub fn next_request_id(&self) -> u32 {
-        self.next_id.fetch_add(1, Ordering::Relaxed)
+    pub fn _next_request_id(&self) -> u32 {
+        self._next_id.fetch_add(1, Ordering::Relaxed)
     }
 }
 
@@ -392,7 +388,7 @@ fn forward_unsolicited(sink: &Option<TokioUnboundedSender<Message>>, msg: Messag
     match sink {
         Some(tx) => {
             if let Err(e) = tx.send(msg) {
-                debug!("unsolicited channel closed: {}", e);
+                debug!("unsolicited channel closed: {e}");
             }
         }
         None => {
@@ -422,11 +418,13 @@ fn decode_response(original_id: RequestId, resp: proto::Response) -> Result<Resp
 
 /// Server-side handler for decoded envelopes.
 #[async_trait::async_trait]
+#[allow(dead_code)]
 pub trait RpcHandler {
     async fn handle_message(&self, message: Message) -> Result<Option<Message>>;
 }
 
 /// RPC server that reads Envelopes from a byte stream and dispatches to a handler.
+#[allow(dead_code)]
 pub struct RpcServer {
     handler: Box<dyn RpcHandler + Send + Sync>,
 }
@@ -452,7 +450,7 @@ impl RpcServer {
                     let incoming_msg = match envelope_to_message(envelope) {
                         Ok(msg) => msg,
                         Err(e) => {
-                            warn!("Failed to decode envelope: {}", e);
+                            warn!("Failed to decode envelope: {e}");
                             continue;
                         }
                     };
@@ -463,20 +461,20 @@ impl RpcServer {
                                 match message_to_response_envelope(response_msg, envelope_id) {
                                     Ok(env) => env,
                                     Err(e) => {
-                                        warn!("Failed to encode response: {}", e);
+                                        warn!("Failed to encode response: {e}");
                                         continue;
                                     }
                                 };
                             if let Err(e) =
                                 write_envelope(&mut stream, &mut buffer, response_envelope).await
                             {
-                                error!("Failed to write response envelope: {}", e);
+                                error!("Failed to write response envelope: {e}");
                                 break;
                             }
                         }
                         Ok(None) => {}
                         Err(e) => {
-                            warn!("Handler error: {}", e);
+                            warn!("Handler error: {e}");
                             if let Some(env_id) = envelope_id {
                                 let error_envelope = Envelope {
                                     id: None,
@@ -493,7 +491,7 @@ impl RpcServer {
                                 if let Err(we) =
                                     write_envelope(&mut stream, &mut buffer, error_envelope).await
                                 {
-                                    error!("Failed to write error envelope: {}", we);
+                                    error!("Failed to write error envelope: {we}");
                                     break;
                                 }
                             }
@@ -501,7 +499,7 @@ impl RpcServer {
                     }
                 }
                 Err(e) => {
-                    error!("RPC server read error: {}", e);
+                    error!("RPC server read error: {e}");
                     break;
                 }
             }
@@ -513,6 +511,7 @@ impl RpcServer {
 
 /// Translate an incoming Envelope into an internal Message. The caller is
 /// responsible for using `envelope.id` when producing a response.
+#[allow(dead_code)]
 fn envelope_to_message(envelope: Envelope) -> Result<Message> {
     let payload = envelope
         .payload
@@ -543,6 +542,7 @@ fn envelope_to_message(envelope: Envelope) -> Result<Message> {
 }
 
 /// Encode a server-produced Response Message into a correlated Envelope.
+#[allow(dead_code)]
 fn message_to_response_envelope(message: Message, responding_to: Option<u32>) -> Result<Envelope> {
     let response = match message {
         Message::Response(r) => r,

--- a/src/remote/rpc.rs
+++ b/src/remote/rpc.rs
@@ -1,0 +1,545 @@
+use anyhow::{anyhow, Result};
+use futures::channel::mpsc::{UnboundedReceiver, UnboundedSender};
+use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, StreamExt};
+use log::{debug, error, info, warn};
+use prost::Message as ProstMessage;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use tokio::sync::oneshot;
+use tokio::time::{timeout, Duration};
+
+use crate::lsp::jsonrpc;
+use crate::msg::{Message, Notification, Request, RequestId, Response};
+
+pub mod proto {
+    include!(concat!(env!("OUT_DIR"), "/lsp_proxy.rpc.rs"));
+}
+
+use proto::{envelope, Envelope, RpcError};
+
+/// Wire format length type. Each Envelope is framed by a 4-byte LE length prefix.
+pub type MessageLen = u32;
+pub const MESSAGE_LEN_SIZE: usize = std::mem::size_of::<MessageLen>();
+/// 10 MiB hard cap on a single envelope to avoid runaway allocations.
+const MAX_MESSAGE_LEN: u32 = 10 * 1024 * 1024;
+
+/// Raw-envelope reader for the server side.
+pub async fn read_envelope<S: AsyncRead + Unpin>(
+    stream: &mut S,
+    buffer: &mut Vec<u8>,
+) -> Result<Envelope> {
+    buffer.resize(MESSAGE_LEN_SIZE, 0);
+    stream.read_exact(buffer).await?;
+    let message_len = MessageLen::from_le_bytes(buffer.as_slice().try_into().unwrap());
+    if message_len == 0 || message_len > MAX_MESSAGE_LEN {
+        return Err(anyhow!("Invalid envelope length: {}", message_len));
+    }
+    buffer.resize(message_len as usize, 0);
+    stream.read_exact(buffer).await?;
+    Envelope::decode(buffer.as_slice()).map_err(Into::into)
+}
+
+/// Raw-envelope writer for the server side.
+pub async fn write_envelope<S: AsyncWrite + Unpin>(
+    stream: &mut S,
+    buffer: &mut Vec<u8>,
+    envelope: Envelope,
+) -> Result<()> {
+    let message_len = envelope.encoded_len() as u32;
+    stream.write_all(&message_len.to_le_bytes()).await?;
+    buffer.clear();
+    buffer.reserve(message_len as usize);
+    envelope.encode(buffer)?;
+    stream.write_all(buffer).await?;
+    stream.flush().await?;
+    Ok(())
+}
+
+/// Outgoing message destined for the wire.
+#[derive(Debug)]
+enum OutgoingCommand {
+    Request {
+        request: Request,
+        response_tx: oneshot::Sender<Result<Response>>,
+    },
+    Notification(Notification),
+}
+
+/// RPC client that speaks Protobuf-framed Envelopes over a duplex byte stream.
+pub struct RpcClient {
+    sender: UnboundedSender<OutgoingCommand>,
+    next_id: Arc<AtomicU32>,
+}
+
+impl RpcClient {
+    pub fn new<S>(stream: S) -> Result<Self>
+    where
+        S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+    {
+        let (sender, receiver) = futures::channel::mpsc::unbounded();
+        tokio::spawn(Self::run_communication_loop(stream, receiver));
+        Ok(Self {
+            sender,
+            next_id: Arc::new(AtomicU32::new(1)),
+        })
+    }
+
+    pub async fn send_request(&self, request: Request) -> Result<Response> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender
+            .unbounded_send(OutgoingCommand::Request {
+                request,
+                response_tx,
+            })
+            .map_err(|_| anyhow!("RPC client channel closed"))?;
+
+        let response = timeout(Duration::from_secs(30), response_rx)
+            .await
+            .map_err(|_| anyhow!("RPC request timeout"))?
+            .map_err(|_| anyhow!("Response channel closed"))??;
+        Ok(response)
+    }
+
+    pub fn send_notification(&self, notification: Notification) -> Result<()> {
+        self.sender
+            .unbounded_send(OutgoingCommand::Notification(notification))
+            .map_err(|_| anyhow!("RPC client channel closed"))?;
+        Ok(())
+    }
+
+    async fn run_communication_loop<S>(mut stream: S, mut receiver: UnboundedReceiver<OutgoingCommand>)
+    where
+        S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+    {
+        // envelope_id -> (original LSP request id, response sender)
+        let mut pending: HashMap<u32, (RequestId, oneshot::Sender<Result<Response>>)> =
+            HashMap::new();
+        let mut next_envelope_id: u32 = 1;
+        let mut buffer = Vec::new();
+
+        loop {
+            tokio::select! {
+                outgoing = receiver.next() => {
+                    match outgoing {
+                        Some(OutgoingCommand::Request { request, response_tx }) => {
+                            let envelope_id = next_envelope_id;
+                            next_envelope_id = next_envelope_id.wrapping_add(1);
+                            let original_id = request.id.clone();
+
+                            let params_bytes = match serde_json::to_vec(&request.params) {
+                                Ok(b) => b,
+                                Err(e) => {
+                                    let _ = response_tx.send(Err(anyhow!("encode params: {}", e)));
+                                    continue;
+                                }
+                            };
+                            let envelope = Envelope {
+                                id: Some(envelope_id),
+                                responding_to: None,
+                                payload: Some(envelope::Payload::Request(proto::Request {
+                                    method: request.method,
+                                    params: params_bytes,
+                                })),
+                            };
+                            if let Err(e) = write_envelope(&mut stream, &mut buffer, envelope).await {
+                                error!("Failed to write request envelope: {}", e);
+                                let _ = response_tx.send(Err(e));
+                                break;
+                            }
+                            pending.insert(envelope_id, (original_id, response_tx));
+                        }
+                        Some(OutgoingCommand::Notification(notif)) => {
+                            let params_bytes = match serde_json::to_vec(&notif.params) {
+                                Ok(b) => b,
+                                Err(e) => {
+                                    warn!("Failed to encode notification params: {}", e);
+                                    continue;
+                                }
+                            };
+                            let envelope = Envelope {
+                                id: None,
+                                responding_to: None,
+                                payload: Some(envelope::Payload::Notification(proto::Notification {
+                                    method: notif.method,
+                                    params: params_bytes,
+                                })),
+                            };
+                            if let Err(e) = write_envelope(&mut stream, &mut buffer, envelope).await {
+                                error!("Failed to write notification envelope: {}", e);
+                                break;
+                            }
+                        }
+                        None => {
+                            debug!("RPC outgoing channel closed");
+                            break;
+                        }
+                    }
+                }
+                incoming = read_envelope(&mut stream, &mut buffer) => {
+                    match incoming {
+                        Ok(envelope) => {
+                            if let Some(envelope::Payload::Response(resp)) = envelope.payload {
+                                if let Some(env_id) = envelope.responding_to {
+                                    if let Some((orig_id, tx)) = pending.remove(&env_id) {
+                                        let response = decode_response(orig_id, resp);
+                                        let _ = tx.send(response);
+                                    } else {
+                                        debug!("Unmatched response envelope id={}", env_id);
+                                    }
+                                } else {
+                                    debug!("Response envelope missing responding_to");
+                                }
+                            } else {
+                                // Client currently ignores server-initiated requests and notifications.
+                                debug!("Ignoring non-response envelope from server");
+                            }
+                        }
+                        Err(e) => {
+                            error!("RPC read error: {}", e);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        for (_, (_, tx)) in pending {
+            let _ = tx.send(Err(anyhow!("RPC connection closed")));
+        }
+    }
+
+    pub fn next_request_id(&self) -> u32 {
+        self.next_id.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+fn decode_response(original_id: RequestId, resp: proto::Response) -> Result<Response> {
+    let result = match resp.result {
+        Some(bytes) => Some(serde_json::from_slice::<serde_json::Value>(&bytes)?),
+        None => None,
+    };
+    let error = resp.error.map(|e| jsonrpc::Error {
+        code: jsonrpc::ErrorCode::from(e.code as i64),
+        message: e.message,
+        data: e
+            .data
+            .and_then(|d| serde_json::from_slice::<serde_json::Value>(&d).ok()),
+    });
+    Ok(Response {
+        id: original_id,
+        result,
+        error,
+    })
+}
+
+/// Server-side handler for decoded envelopes.
+#[async_trait::async_trait]
+pub trait RpcHandler {
+    async fn handle_message(&self, message: Message) -> Result<Option<Message>>;
+}
+
+/// RPC server that reads Envelopes from a byte stream and dispatches to a handler.
+pub struct RpcServer {
+    handler: Box<dyn RpcHandler + Send + Sync>,
+}
+
+impl RpcServer {
+    pub fn new<H: RpcHandler + Send + Sync + 'static>(handler: H) -> Self {
+        Self {
+            handler: Box::new(handler),
+        }
+    }
+
+    pub async fn serve<S>(&self, mut stream: S) -> Result<()>
+    where
+        S: AsyncRead + AsyncWrite + Send + Unpin,
+    {
+        info!("RPC server started");
+        let mut buffer = Vec::new();
+
+        loop {
+            match read_envelope(&mut stream, &mut buffer).await {
+                Ok(envelope) => {
+                    let envelope_id = envelope.id;
+                    let incoming_msg = match envelope_to_message(envelope) {
+                        Ok(msg) => msg,
+                        Err(e) => {
+                            warn!("Failed to decode envelope: {}", e);
+                            continue;
+                        }
+                    };
+
+                    match self.handler.handle_message(incoming_msg).await {
+                        Ok(Some(response_msg)) => {
+                            let response_envelope =
+                                match message_to_response_envelope(response_msg, envelope_id) {
+                                    Ok(env) => env,
+                                    Err(e) => {
+                                        warn!("Failed to encode response: {}", e);
+                                        continue;
+                                    }
+                                };
+                            if let Err(e) =
+                                write_envelope(&mut stream, &mut buffer, response_envelope).await
+                            {
+                                error!("Failed to write response envelope: {}", e);
+                                break;
+                            }
+                        }
+                        Ok(None) => {}
+                        Err(e) => {
+                            warn!("Handler error: {}", e);
+                            if let Some(env_id) = envelope_id {
+                                let error_envelope = Envelope {
+                                    id: None,
+                                    responding_to: Some(env_id),
+                                    payload: Some(envelope::Payload::Response(proto::Response {
+                                        result: None,
+                                        error: Some(RpcError {
+                                            code: -32000,
+                                            message: e.to_string(),
+                                            data: None,
+                                        }),
+                                    })),
+                                };
+                                if let Err(we) =
+                                    write_envelope(&mut stream, &mut buffer, error_envelope).await
+                                {
+                                    error!("Failed to write error envelope: {}", we);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!("RPC server read error: {}", e);
+                    break;
+                }
+            }
+        }
+        info!("RPC server stopped");
+        Ok(())
+    }
+}
+
+/// Translate an incoming Envelope into an internal Message. The caller is
+/// responsible for using `envelope.id` when producing a response.
+fn envelope_to_message(envelope: Envelope) -> Result<Message> {
+    let payload = envelope
+        .payload
+        .ok_or_else(|| anyhow!("envelope missing payload"))?;
+    match payload {
+        envelope::Payload::Request(req) => {
+            let params: crate::msg::Params = serde_json::from_slice(&req.params)?;
+            let id_numeric = envelope
+                .id
+                .ok_or_else(|| anyhow!("request envelope missing id"))?;
+            Ok(Message::Request(Request {
+                id: RequestId::from(id_numeric as i32),
+                method: req.method,
+                params,
+            }))
+        }
+        envelope::Payload::Notification(notif) => {
+            let params: crate::msg::Params = serde_json::from_slice(&notif.params)?;
+            Ok(Message::Notification(Notification {
+                method: notif.method,
+                params,
+            }))
+        }
+        envelope::Payload::Response(_) => {
+            Err(anyhow!("Unexpected response envelope on server side"))
+        }
+    }
+}
+
+/// Encode a server-produced Response Message into a correlated Envelope.
+fn message_to_response_envelope(message: Message, responding_to: Option<u32>) -> Result<Envelope> {
+    let response = match message {
+        Message::Response(r) => r,
+        _ => return Err(anyhow!("handler returned non-response message")),
+    };
+    let result = match response.result {
+        Some(v) => Some(serde_json::to_vec(&v)?),
+        None => None,
+    };
+    let error = response.error.map(|e| RpcError {
+        code: e.code.code() as i32,
+        message: e.message,
+        data: e
+            .data
+            .as_ref()
+            .and_then(|d| serde_json::to_vec(d).ok()),
+    });
+    Ok(Envelope {
+        id: None,
+        responding_to,
+        payload: Some(envelope::Payload::Response(proto::Response {
+            result,
+            error,
+        })),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::msg::{Notification as MsgNotification, Params};
+    use std::sync::{Arc, Mutex};
+    use tokio_util::compat::TokioAsyncReadCompatExt;
+
+    #[test]
+    fn envelope_round_trip() {
+        let env = Envelope {
+            id: Some(42),
+            responding_to: None,
+            payload: Some(envelope::Payload::Request(proto::Request {
+                method: "textDocument/hover".into(),
+                params: b"{}".to_vec(),
+            })),
+        };
+        let mut buf = Vec::new();
+        env.clone().encode(&mut buf).unwrap();
+        let decoded = Envelope::decode(buf.as_slice()).unwrap();
+        assert_eq!(env.id, decoded.id);
+        match decoded.payload.unwrap() {
+            envelope::Payload::Request(r) => {
+                assert_eq!(r.method, "textDocument/hover");
+                assert_eq!(r.params, b"{}");
+            }
+            _ => panic!("expected request"),
+        }
+    }
+
+    /// Test handler that echoes back the request id inside the result, and
+    /// captures any notifications it sees for later assertion.
+    struct EchoHandler {
+        notifications: Arc<Mutex<Vec<MsgNotification>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl RpcHandler for EchoHandler {
+        async fn handle_message(&self, message: Message) -> Result<Option<Message>> {
+            match message {
+                Message::Request(req) => {
+                    // Fail loudly on a specific method so we can exercise the
+                    // error path as well.
+                    if req.method == "force_error" {
+                        return Err(anyhow!("boom"));
+                    }
+                    Ok(Some(Message::Response(Response {
+                        id: req.id.clone(),
+                        result: Some(serde_json::json!({
+                            "method": req.method,
+                            "echoed_uri": req.params.uri,
+                        })),
+                        error: None,
+                    })))
+                }
+                Message::Notification(notif) => {
+                    self.notifications.lock().unwrap().push(notif);
+                    Ok(None)
+                }
+                Message::Response(_) => Ok(None),
+            }
+        }
+    }
+
+    /// Build a `Params` that carries the same shape Emacs sends, so the
+    /// request/response path is exercised on real serde paths.
+    fn params_with_uri(uri: &str) -> Params {
+        Params {
+            uri: Some(uri.to_string()),
+            context: None,
+            virtual_doc: None,
+            params: serde_json::json!({ "textDocument": { "uri": uri } }),
+        }
+    }
+
+    /// Stand up a client↔server pair connected over an in-memory duplex
+    /// stream. Returns the client so the test can drive it.
+    async fn spawn_pair(
+        notifications: Arc<Mutex<Vec<MsgNotification>>>,
+    ) -> RpcClient {
+        let (client_side, server_side) = tokio::io::duplex(1 << 16);
+
+        // RpcClient wants futures::{AsyncRead, AsyncWrite}. Tokio's DuplexStream
+        // only implements the tokio traits, so wrap both halves with compat.
+        // `Compat<T>` already implements both futures traits when `T` implements
+        // the tokio ones, so a single `.compat()` is enough.
+        let client_stream = client_side.compat();
+        let server_stream = server_side.compat();
+
+        tokio::spawn(async move {
+            let server = RpcServer::new(EchoHandler { notifications });
+            let _ = server.serve(server_stream).await;
+        });
+
+        RpcClient::new(client_stream).expect("build RpcClient")
+    }
+
+    #[tokio::test]
+    async fn request_response_round_trip() {
+        let notifs = Arc::new(Mutex::new(Vec::new()));
+        let client = spawn_pair(notifs.clone()).await;
+
+        let req = Request {
+            id: crate::msg::RequestId::from(7),
+            method: "textDocument/hover".into(),
+            params: params_with_uri("file:///tmp/foo.rs"),
+        };
+
+        let resp = client.send_request(req).await.expect("request ok");
+        assert_eq!(resp.id, crate::msg::RequestId::from(7));
+        assert!(resp.error.is_none(), "expected no error, got {:?}", resp.error);
+        let result = resp.result.expect("result should be present");
+        assert_eq!(result["method"], "textDocument/hover");
+        assert_eq!(result["echoed_uri"], "file:///tmp/foo.rs");
+    }
+
+    #[tokio::test]
+    async fn notification_delivered_to_handler() {
+        let notifs = Arc::new(Mutex::new(Vec::new()));
+        let client = spawn_pair(notifs.clone()).await;
+
+        let notif = MsgNotification {
+            method: "textDocument/didChange".into(),
+            params: params_with_uri("file:///tmp/bar.rs"),
+        };
+        client.send_notification(notif).expect("send notification");
+
+        // Give the server task a chance to pick the notification up.
+        for _ in 0..100 {
+            if !notifs.lock().unwrap().is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        let collected = notifs.lock().unwrap();
+        assert_eq!(collected.len(), 1);
+        assert_eq!(collected[0].method, "textDocument/didChange");
+        assert_eq!(
+            collected[0].params.uri.as_deref(),
+            Some("file:///tmp/bar.rs")
+        );
+    }
+
+    #[tokio::test]
+    async fn handler_error_surfaces_as_rpc_error() {
+        let notifs = Arc::new(Mutex::new(Vec::new()));
+        let client = spawn_pair(notifs).await;
+
+        let req = Request {
+            id: crate::msg::RequestId::from(99),
+            method: "force_error".into(),
+            params: params_with_uri("file:///tmp/x.rs"),
+        };
+        let resp = client.send_request(req).await.expect("transport ok");
+        assert_eq!(resp.id, crate::msg::RequestId::from(99));
+        let err = resp.error.expect("expected RpcError");
+        assert_eq!(err.message, "boom");
+    }
+}

--- a/src/remote/rpc.rs
+++ b/src/remote/rpc.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use futures::channel::mpsc::{UnboundedReceiver, UnboundedSender};
 use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, StreamExt};
-use log::{debug, error, info, warn};
+use log::{debug, error, warn};
 use prost::Message as ProstMessage;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
@@ -29,7 +29,7 @@ pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/lsp_proxy.rpc.rs"));
 }
 
-use proto::{envelope, Envelope, RpcError};
+use proto::{envelope, Envelope};
 
 /// Wire format length type. Each Envelope is framed by a 4-byte LE length prefix.
 pub type MessageLen = u32;
@@ -416,166 +416,166 @@ fn decode_response(original_id: RequestId, resp: proto::Response) -> Result<Resp
     })
 }
 
-/// Server-side handler for decoded envelopes.
-#[async_trait::async_trait]
-#[allow(dead_code)]
-pub trait RpcHandler {
-    async fn handle_message(&self, message: Message) -> Result<Option<Message>>;
-}
-
-/// RPC server that reads Envelopes from a byte stream and dispatches to a handler.
-#[allow(dead_code)]
-pub struct RpcServer {
-    handler: Box<dyn RpcHandler + Send + Sync>,
-}
-
-impl RpcServer {
-    pub fn new<H: RpcHandler + Send + Sync + 'static>(handler: H) -> Self {
-        Self {
-            handler: Box::new(handler),
-        }
-    }
-
-    pub async fn serve<S>(&self, mut stream: S) -> Result<()>
-    where
-        S: AsyncRead + AsyncWrite + Send + Unpin,
-    {
-        info!("RPC server started");
-        let mut buffer = Vec::new();
-
-        loop {
-            match read_envelope(&mut stream, &mut buffer).await {
-                Ok(envelope) => {
-                    let envelope_id = envelope.id;
-                    let incoming_msg = match envelope_to_message(envelope) {
-                        Ok(msg) => msg,
-                        Err(e) => {
-                            warn!("Failed to decode envelope: {e}");
-                            continue;
-                        }
-                    };
-
-                    match self.handler.handle_message(incoming_msg).await {
-                        Ok(Some(response_msg)) => {
-                            let response_envelope =
-                                match message_to_response_envelope(response_msg, envelope_id) {
-                                    Ok(env) => env,
-                                    Err(e) => {
-                                        warn!("Failed to encode response: {e}");
-                                        continue;
-                                    }
-                                };
-                            if let Err(e) =
-                                write_envelope(&mut stream, &mut buffer, response_envelope).await
-                            {
-                                error!("Failed to write response envelope: {e}");
-                                break;
-                            }
-                        }
-                        Ok(None) => {}
-                        Err(e) => {
-                            warn!("Handler error: {e}");
-                            if let Some(env_id) = envelope_id {
-                                let error_envelope = Envelope {
-                                    id: None,
-                                    responding_to: Some(env_id),
-                                    payload: Some(envelope::Payload::Response(proto::Response {
-                                        result: None,
-                                        error: Some(RpcError {
-                                            code: -32000,
-                                            message: e.to_string(),
-                                            data: None,
-                                        }),
-                                    })),
-                                };
-                                if let Err(we) =
-                                    write_envelope(&mut stream, &mut buffer, error_envelope).await
-                                {
-                                    error!("Failed to write error envelope: {we}");
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-                Err(e) => {
-                    error!("RPC server read error: {e}");
-                    break;
-                }
-            }
-        }
-        info!("RPC server stopped");
-        Ok(())
-    }
-}
-
-/// Translate an incoming Envelope into an internal Message. The caller is
-/// responsible for using `envelope.id` when producing a response.
-#[allow(dead_code)]
-fn envelope_to_message(envelope: Envelope) -> Result<Message> {
-    let payload = envelope
-        .payload
-        .ok_or_else(|| anyhow!("envelope missing payload"))?;
-    match payload {
-        envelope::Payload::Request(req) => {
-            let params: crate::msg::Params = serde_json::from_slice(&req.params)?;
-            let id_numeric = envelope
-                .id
-                .ok_or_else(|| anyhow!("request envelope missing id"))?;
-            Ok(Message::Request(Request {
-                id: RequestId::from(id_numeric as i32),
-                method: req.method,
-                params,
-            }))
-        }
-        envelope::Payload::Notification(notif) => {
-            let params: crate::msg::Params = serde_json::from_slice(&notif.params)?;
-            Ok(Message::Notification(Notification {
-                method: notif.method,
-                params,
-            }))
-        }
-        envelope::Payload::Response(_) => {
-            Err(anyhow!("Unexpected response envelope on server side"))
-        }
-    }
-}
-
-/// Encode a server-produced Response Message into a correlated Envelope.
-#[allow(dead_code)]
-fn message_to_response_envelope(message: Message, responding_to: Option<u32>) -> Result<Envelope> {
-    let response = match message {
-        Message::Response(r) => r,
-        _ => return Err(anyhow!("handler returned non-response message")),
-    };
-    let result = match response.result {
-        Some(v) => Some(serde_json::to_vec(&v)?),
-        None => None,
-    };
-    let error = response.error.map(|e| RpcError {
-        code: e.code.code() as i32,
-        message: e.message,
-        data: e
-            .data
-            .as_ref()
-            .and_then(|d| serde_json::to_vec(d).ok()),
-    });
-    Ok(Envelope {
-        id: None,
-        responding_to,
-        payload: Some(envelope::Payload::Response(proto::Response {
-            result,
-            error,
-        })),
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::msg::{Notification as MsgNotification, Params};
+    use log::info;
+    use proto::RpcError;
     use std::sync::{Arc, Mutex};
     use tokio_util::compat::TokioAsyncReadCompatExt;
+
+    #[async_trait::async_trait]
+    trait RpcHandler {
+        async fn handle_message(&self, message: Message) -> Result<Option<Message>>;
+    }
+
+    struct RpcServer {
+        handler: Box<dyn RpcHandler + Send + Sync>,
+    }
+
+    impl RpcServer {
+        fn new<H: RpcHandler + Send + Sync + 'static>(handler: H) -> Self {
+            Self {
+                handler: Box::new(handler),
+            }
+        }
+
+        async fn serve<S>(&self, mut stream: S) -> Result<()>
+        where
+            S: AsyncRead + AsyncWrite + Send + Unpin,
+        {
+            info!("RPC server started");
+            let mut buffer = Vec::new();
+
+            loop {
+                match read_envelope(&mut stream, &mut buffer).await {
+                    Ok(envelope) => {
+                        let envelope_id = envelope.id;
+                        let incoming_msg = match envelope_to_message(envelope) {
+                            Ok(msg) => msg,
+                            Err(e) => {
+                                warn!("Failed to decode envelope: {e}");
+                                continue;
+                            }
+                        };
+
+                        match self.handler.handle_message(incoming_msg).await {
+                            Ok(Some(response_msg)) => {
+                                let response_envelope =
+                                    match message_to_response_envelope(response_msg, envelope_id) {
+                                        Ok(env) => env,
+                                        Err(e) => {
+                                            warn!("Failed to encode response: {e}");
+                                            continue;
+                                        }
+                                    };
+                                if let Err(e) =
+                                    write_envelope(&mut stream, &mut buffer, response_envelope)
+                                        .await
+                                {
+                                    error!("Failed to write response envelope: {e}");
+                                    break;
+                                }
+                            }
+                            Ok(None) => {}
+                            Err(e) => {
+                                warn!("Handler error: {e}");
+                                if let Some(env_id) = envelope_id {
+                                    let error_envelope = Envelope {
+                                        id: None,
+                                        responding_to: Some(env_id),
+                                        payload: Some(envelope::Payload::Response(
+                                            proto::Response {
+                                                result: None,
+                                                error: Some(RpcError {
+                                                    code: -32000,
+                                                    message: e.to_string(),
+                                                    data: None,
+                                                }),
+                                            },
+                                        )),
+                                    };
+                                    if let Err(we) =
+                                        write_envelope(&mut stream, &mut buffer, error_envelope)
+                                            .await
+                                    {
+                                        error!("Failed to write error envelope: {we}");
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        error!("RPC server read error: {e}");
+                        break;
+                    }
+                }
+            }
+            info!("RPC server stopped");
+            Ok(())
+        }
+    }
+
+    fn envelope_to_message(envelope: Envelope) -> Result<Message> {
+        let payload = envelope
+            .payload
+            .ok_or_else(|| anyhow!("envelope missing payload"))?;
+        match payload {
+            envelope::Payload::Request(req) => {
+                let params: crate::msg::Params = serde_json::from_slice(&req.params)?;
+                let id_numeric = envelope
+                    .id
+                    .ok_or_else(|| anyhow!("request envelope missing id"))?;
+                Ok(Message::Request(Request {
+                    id: RequestId::from(id_numeric as i32),
+                    method: req.method,
+                    params,
+                }))
+            }
+            envelope::Payload::Notification(notif) => {
+                let params: crate::msg::Params = serde_json::from_slice(&notif.params)?;
+                Ok(Message::Notification(Notification {
+                    method: notif.method,
+                    params,
+                }))
+            }
+            envelope::Payload::Response(_) => {
+                Err(anyhow!("Unexpected response envelope on server side"))
+            }
+        }
+    }
+
+    fn message_to_response_envelope(
+        message: Message,
+        responding_to: Option<u32>,
+    ) -> Result<Envelope> {
+        let response = match message {
+            Message::Response(r) => r,
+            _ => return Err(anyhow!("handler returned non-response message")),
+        };
+        let result = match response.result {
+            Some(v) => Some(serde_json::to_vec(&v)?),
+            None => None,
+        };
+        let error = response.error.map(|e| RpcError {
+            code: e.code.code() as i32,
+            message: e.message,
+            data: e
+                .data
+                .as_ref()
+                .and_then(|d| serde_json::to_vec(d).ok()),
+        });
+        Ok(Envelope {
+            id: None,
+            responding_to,
+            payload: Some(envelope::Payload::Response(proto::Response {
+                result,
+                error,
+            })),
+        })
+    }
 
     #[test]
     fn envelope_round_trip() {

--- a/src/remote/rpc.rs
+++ b/src/remote/rpc.rs
@@ -106,6 +106,8 @@ impl RpcClient {
 
     pub async fn send_request(&self, request: Request) -> Result<Response> {
         let (response_tx, response_rx) = oneshot::channel();
+        let method = request.method.clone();
+        let orig_id = request.id.clone();
         self.sender
             .unbounded_send(OutgoingCommand::Request {
                 request,
@@ -113,11 +115,19 @@ impl RpcClient {
             })
             .map_err(|_| anyhow!("RPC client channel closed"))?;
 
-        let response = timeout(Duration::from_secs(30), response_rx)
-            .await
-            .map_err(|_| anyhow!("RPC request timeout"))?
-            .map_err(|_| anyhow!("Response channel closed"))??;
-        Ok(response)
+        match timeout(Duration::from_secs(30), response_rx).await {
+            Ok(inner) => {
+                let response = inner.map_err(|_| anyhow!("Response channel closed"))??;
+                Ok(response)
+            }
+            Err(_) => {
+                warn!(
+                    "RPC request timeout after 30s: method={} orig_id={:?}",
+                    method, orig_id
+                );
+                Err(anyhow!("RPC request timeout"))
+            }
+        }
     }
 
     pub fn send_notification(&self, notification: Notification) -> Result<()> {
@@ -156,6 +166,11 @@ impl RpcClient {
                                     continue;
                                 }
                             };
+                            let method_for_log = request.method.clone();
+                            debug!(
+                                "RPC send request env_id={} method={} orig_id={:?}",
+                                envelope_id, method_for_log, original_id
+                            );
                             let envelope = Envelope {
                                 id: Some(envelope_id),
                                 responding_to: None,

--- a/src/remote/rpc.rs
+++ b/src/remote/rpc.rs
@@ -86,6 +86,7 @@ pub struct RpcClient {
     /// Set to true by the heartbeat task when it decides the far end is
     /// unresponsive (N consecutive ping misses). Checked by `is_dead()`.
     dead: Arc<AtomicBool>,
+    transport_killer: Option<Arc<dyn Fn() + Send + Sync>>,
 }
 
 impl RpcClient {
@@ -102,6 +103,17 @@ impl RpcClient {
     where
         S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
     {
+        Self::new_with_transport_killer(stream, unsolicited, None)
+    }
+
+    pub fn new_with_transport_killer<S>(
+        stream: S,
+        unsolicited: Option<TokioUnboundedSender<Message>>,
+        transport_killer: Option<Arc<dyn Fn() + Send + Sync>>,
+    ) -> Result<Self>
+    where
+        S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+    {
         let (sender, receiver) = futures::channel::mpsc::unbounded();
         tokio::spawn(Self::run_communication_loop(stream, receiver, unsolicited));
         let dead = Arc::new(AtomicBool::new(false));
@@ -110,6 +122,7 @@ impl RpcClient {
             sender,
             _next_id: Arc::new(AtomicU32::new(1)),
             dead,
+            transport_killer,
         })
     }
 
@@ -190,6 +203,21 @@ impl RpcClient {
     ///   timeout, repeatedly.
     pub fn is_dead(&self) -> bool {
         self.sender.is_closed() || self.dead.load(Ordering::Relaxed)
+    }
+
+    /// Synchronously tear down the underlying transport.
+    ///
+    /// This is used from the `process::exit()` path, where async Drop handlers
+    /// will not run. Closing the command channel alone is insufficient because
+    /// background tasks may still hold sender clones; the transport-specific
+    /// killer must explicitly terminate the child process that carries the
+    /// remote RPC stream.
+    pub fn kill_transport_sync(&self) {
+        self.dead.store(true, Ordering::Relaxed);
+        self.sender.close_channel();
+        if let Some(kill) = &self.transport_killer {
+            kill();
+        }
     }
 
     pub async fn send_request(&self, request: Request) -> Result<Response> {
@@ -685,6 +713,26 @@ mod tests {
         let result = resp.result.expect("result should be present");
         assert_eq!(result["method"], "textDocument/hover");
         assert_eq!(result["echoed_uri"], "file:///tmp/foo.rs");
+    }
+
+    #[tokio::test]
+    async fn kill_transport_sync_invokes_registered_killer() {
+        let (client_side, _server_side) = tokio::io::duplex(1 << 16);
+        let killed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let killed_for_hook = killed.clone();
+        let client = RpcClient::new_with_transport_killer(
+            client_side.compat(),
+            None,
+            Some(Arc::new(move || {
+                killed_for_hook.store(true, Ordering::Relaxed);
+            })),
+        )
+        .expect("build RpcClient");
+
+        client.kill_transport_sync();
+
+        assert!(killed.load(Ordering::Relaxed));
+        assert!(client.is_dead());
     }
 
     #[tokio::test]

--- a/src/remote/rpc.rs
+++ b/src/remote/rpc.rs
@@ -195,6 +195,20 @@ impl RpcClient {
                             Some(envelope::Payload::Response(resp)) => {
                                 if let Some(env_id) = envelope.responding_to {
                                     if let Some((orig_id, tx)) = pending.remove(&env_id) {
+                                        debug!(
+                                            "RPC recv response env_id={} orig_id={:?} result_bytes={} error={:?}",
+                                            env_id,
+                                            orig_id,
+                                            resp.result.as_ref().map(|b| b.len()).unwrap_or(0),
+                                            resp.error.as_ref().map(|e| &e.message)
+                                        );
+                                        if let Some(bytes) = resp.result.as_ref() {
+                                            let preview: String = String::from_utf8_lossy(
+                                                &bytes[..bytes.len().min(512)],
+                                            )
+                                            .into_owned();
+                                            debug!("RPC recv result preview: {}", preview);
+                                        }
                                         let response = decode_response(orig_id, resp);
                                         let _ = tx.send(response);
                                     } else {

--- a/src/remote/rpc.rs
+++ b/src/remote/rpc.rs
@@ -86,7 +86,6 @@ pub struct RpcClient {
     /// Set to true by the heartbeat task when it decides the far end is
     /// unresponsive (N consecutive ping misses). Checked by `is_dead()`.
     dead: Arc<AtomicBool>,
-    transport_killer: Option<Arc<dyn Fn() + Send + Sync>>,
 }
 
 impl RpcClient {
@@ -103,17 +102,6 @@ impl RpcClient {
     where
         S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
     {
-        Self::new_with_transport_killer(stream, unsolicited, None)
-    }
-
-    pub fn new_with_transport_killer<S>(
-        stream: S,
-        unsolicited: Option<TokioUnboundedSender<Message>>,
-        transport_killer: Option<Arc<dyn Fn() + Send + Sync>>,
-    ) -> Result<Self>
-    where
-        S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
-    {
         let (sender, receiver) = futures::channel::mpsc::unbounded();
         tokio::spawn(Self::run_communication_loop(stream, receiver, unsolicited));
         let dead = Arc::new(AtomicBool::new(false));
@@ -122,7 +110,6 @@ impl RpcClient {
             sender,
             _next_id: Arc::new(AtomicU32::new(1)),
             dead,
-            transport_killer,
         })
     }
 
@@ -203,21 +190,6 @@ impl RpcClient {
     ///   timeout, repeatedly.
     pub fn is_dead(&self) -> bool {
         self.sender.is_closed() || self.dead.load(Ordering::Relaxed)
-    }
-
-    /// Synchronously tear down the underlying transport.
-    ///
-    /// This is used from the `process::exit()` path, where async Drop handlers
-    /// will not run. Closing the command channel alone is insufficient because
-    /// background tasks may still hold sender clones; the transport-specific
-    /// killer must explicitly terminate the child process that carries the
-    /// remote RPC stream.
-    pub fn kill_transport_sync(&self) {
-        self.dead.store(true, Ordering::Relaxed);
-        self.sender.close_channel();
-        if let Some(kill) = &self.transport_killer {
-            kill();
-        }
     }
 
     pub async fn send_request(&self, request: Request) -> Result<Response> {
@@ -713,26 +685,6 @@ mod tests {
         let result = resp.result.expect("result should be present");
         assert_eq!(result["method"], "textDocument/hover");
         assert_eq!(result["echoed_uri"], "file:///tmp/foo.rs");
-    }
-
-    #[tokio::test]
-    async fn kill_transport_sync_invokes_registered_killer() {
-        let (client_side, _server_side) = tokio::io::duplex(1 << 16);
-        let killed = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let killed_for_hook = killed.clone();
-        let client = RpcClient::new_with_transport_killer(
-            client_side.compat(),
-            None,
-            Some(Arc::new(move || {
-                killed_for_hook.store(true, Ordering::Relaxed);
-            })),
-        )
-        .expect("build RpcClient");
-
-        client.kill_transport_sync();
-
-        assert!(killed.load(Ordering::Relaxed));
-        assert!(client.is_dead());
     }
 
     #[tokio::test]

--- a/src/remote/rpc.rs
+++ b/src/remote/rpc.rs
@@ -6,6 +6,7 @@ use prost::Message as ProstMessage;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
+use tokio::sync::mpsc::UnboundedSender as TokioUnboundedSender;
 use tokio::sync::oneshot;
 use tokio::time::{timeout, Duration};
 
@@ -73,12 +74,21 @@ pub struct RpcClient {
 }
 
 impl RpcClient {
-    pub fn new<S>(stream: S) -> Result<Self>
+    /// Create an RpcClient over `stream`. When `unsolicited` is `Some(_)`,
+    /// server-originated Notifications (and Requests) that arrive on the
+    /// stream are decoded and pushed to that channel, so the caller can
+    /// forward them to Emacs (e.g. for `textDocument/publishDiagnostics`).
+    /// When `None`, they are silently dropped — useful for tests and for
+    /// code paths that only care about request/response round-trips.
+    pub fn new<S>(
+        stream: S,
+        unsolicited: Option<TokioUnboundedSender<Message>>,
+    ) -> Result<Self>
     where
         S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
     {
         let (sender, receiver) = futures::channel::mpsc::unbounded();
-        tokio::spawn(Self::run_communication_loop(stream, receiver));
+        tokio::spawn(Self::run_communication_loop(stream, receiver, unsolicited));
         Ok(Self {
             sender,
             next_id: Arc::new(AtomicU32::new(1)),
@@ -108,8 +118,11 @@ impl RpcClient {
         Ok(())
     }
 
-    async fn run_communication_loop<S>(mut stream: S, mut receiver: UnboundedReceiver<OutgoingCommand>)
-    where
+    async fn run_communication_loop<S>(
+        mut stream: S,
+        mut receiver: UnboundedReceiver<OutgoingCommand>,
+        unsolicited: Option<TokioUnboundedSender<Message>>,
+    ) where
         S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
     {
         // envelope_id -> (original LSP request id, response sender)
@@ -178,8 +191,8 @@ impl RpcClient {
                 }
                 incoming = read_envelope(&mut stream, &mut buffer) => {
                     match incoming {
-                        Ok(envelope) => {
-                            if let Some(envelope::Payload::Response(resp)) = envelope.payload {
+                        Ok(envelope) => match envelope.payload {
+                            Some(envelope::Payload::Response(resp)) => {
                                 if let Some(env_id) = envelope.responding_to {
                                     if let Some((orig_id, tx)) = pending.remove(&env_id) {
                                         let response = decode_response(orig_id, resp);
@@ -190,11 +203,23 @@ impl RpcClient {
                                 } else {
                                     debug!("Response envelope missing responding_to");
                                 }
-                            } else {
-                                // Client currently ignores server-initiated requests and notifications.
-                                debug!("Ignoring non-response envelope from server");
                             }
-                        }
+                            Some(envelope::Payload::Notification(notif)) => {
+                                match decode_notification(notif) {
+                                    Ok(msg) => forward_unsolicited(&unsolicited, msg),
+                                    Err(e) => warn!("bad server notification: {}", e),
+                                }
+                            }
+                            Some(envelope::Payload::Request(req)) => {
+                                match decode_server_request(envelope.id, req) {
+                                    Ok(msg) => forward_unsolicited(&unsolicited, msg),
+                                    Err(e) => warn!("bad server request: {}", e),
+                                }
+                            }
+                            None => {
+                                debug!("envelope with no payload");
+                            }
+                        },
                         Err(e) => {
                             error!("RPC read error: {}", e);
                             break;
@@ -211,6 +236,40 @@ impl RpcClient {
 
     pub fn next_request_id(&self) -> u32 {
         self.next_id.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+fn decode_notification(notif: proto::Notification) -> Result<Message> {
+    let params: crate::msg::Params = serde_json::from_slice(&notif.params)?;
+    Ok(Message::Notification(Notification {
+        method: notif.method,
+        params,
+    }))
+}
+
+fn decode_server_request(envelope_id: Option<u32>, req: proto::Request) -> Result<Message> {
+    let params: crate::msg::Params = serde_json::from_slice(&req.params)?;
+    // Server-initiated requests still need an id so the client can respond.
+    let id = envelope_id
+        .map(|n| RequestId::from(n as i32))
+        .ok_or_else(|| anyhow!("server request envelope missing id"))?;
+    Ok(Message::Request(Request {
+        id,
+        method: req.method,
+        params,
+    }))
+}
+
+fn forward_unsolicited(sink: &Option<TokioUnboundedSender<Message>>, msg: Message) {
+    match sink {
+        Some(tx) => {
+            if let Err(e) = tx.send(msg) {
+                debug!("unsolicited channel closed: {}", e);
+            }
+        }
+        None => {
+            debug!("no unsolicited sink configured, dropping server-initiated message");
+        }
     }
 }
 
@@ -477,7 +536,8 @@ mod tests {
             let _ = server.serve(server_stream).await;
         });
 
-        RpcClient::new(client_stream).expect("build RpcClient")
+        // Tests don't care about server-initiated messages, so pass None.
+        RpcClient::new(client_stream, None).expect("build RpcClient")
     }
 
     #[tokio::test]

--- a/src/remote/rpc.rs
+++ b/src/remote/rpc.rs
@@ -95,6 +95,15 @@ impl RpcClient {
         })
     }
 
+    /// Returns true if the background communication loop has exited (usually
+    /// because the underlying transport died). Cached clients that report
+    /// `is_dead()` must be evicted and recreated before the next request —
+    /// otherwise every subsequent `send_request` fails instantly with
+    /// "channel closed".
+    pub fn is_dead(&self) -> bool {
+        self.sender.is_closed()
+    }
+
     pub async fn send_request(&self, request: Request) -> Result<Response> {
         let (response_tx, response_rx) = oneshot::channel();
         self.sender

--- a/src/remote/rpc.rs
+++ b/src/remote/rpc.rs
@@ -4,14 +4,26 @@ use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, StreamExt};
 use log::{debug, error, info, warn};
 use prost::Message as ProstMessage;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender as TokioUnboundedSender;
 use tokio::sync::oneshot;
 use tokio::time::{timeout, Duration};
 
 use crate::lsp::jsonrpc;
-use crate::msg::{Message, Notification, Request, RequestId, Response};
+use crate::msg::{Message, Notification, Params, Request, RequestId, Response};
+
+/// Method name for application-level heartbeat pings. The remote side
+/// short-circuits this in its Controller and replies with an empty result
+/// without routing the request through Application.
+pub const PING_METHOD: &str = "$/lspProxy/ping";
+
+/// How often the heartbeat task emits a ping.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+/// How long a single ping is allowed to take before it counts as missed.
+const PING_TIMEOUT: Duration = Duration::from_secs(5);
+/// Consecutive misses that mark the client dead. 5 × 5s ≈ 25s detection.
+const MAX_MISSED_HEARTBEATS: u32 = 5;
 
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/lsp_proxy.rpc.rs"));
@@ -71,6 +83,9 @@ enum OutgoingCommand {
 pub struct RpcClient {
     sender: UnboundedSender<OutgoingCommand>,
     next_id: Arc<AtomicU32>,
+    /// Set to true by the heartbeat task when it decides the far end is
+    /// unresponsive (N consecutive ping misses). Checked by `is_dead()`.
+    dead: Arc<AtomicBool>,
 }
 
 impl RpcClient {
@@ -89,19 +104,94 @@ impl RpcClient {
     {
         let (sender, receiver) = futures::channel::mpsc::unbounded();
         tokio::spawn(Self::run_communication_loop(stream, receiver, unsolicited));
+        let dead = Arc::new(AtomicBool::new(false));
+        tokio::spawn(Self::heartbeat_loop(sender.clone(), dead.clone()));
         Ok(Self {
             sender,
             next_id: Arc::new(AtomicU32::new(1)),
+            dead,
         })
     }
 
-    /// Returns true if the background communication loop has exited (usually
-    /// because the underlying transport died). Cached clients that report
-    /// `is_dead()` must be evicted and recreated before the next request —
-    /// otherwise every subsequent `send_request` fails instantly with
-    /// "channel closed".
+    /// Application-level heartbeat: send a tiny ping every few seconds and
+    /// count consecutive misses. When the miss count hits the threshold, flip
+    /// the `dead` flag so the next `get_or_create_rpc_client` call evicts
+    /// this zombie and rebuilds the tunnel. This catches "tunnel is alive,
+    /// but remote stopped responding" cases that pure stream-EOF detection
+    /// misses.
+    async fn heartbeat_loop(
+        sender: UnboundedSender<OutgoingCommand>,
+        dead: Arc<AtomicBool>,
+    ) {
+        let mut consecutive_misses: u32 = 0;
+        loop {
+            tokio::time::sleep(HEARTBEAT_INTERVAL).await;
+
+            if dead.load(Ordering::Relaxed) || sender.is_closed() {
+                debug!("heartbeat: client already dead, stopping");
+                return;
+            }
+
+            let (resp_tx, resp_rx) = oneshot::channel();
+            let ping_req = Request {
+                id: RequestId::from(-1),
+                method: PING_METHOD.to_string(),
+                params: Params {
+                    uri: None,
+                    context: None,
+                    virtual_doc: None,
+                    params: serde_json::Value::Null,
+                },
+            };
+            if sender
+                .unbounded_send(OutgoingCommand::Request {
+                    request: ping_req,
+                    response_tx: resp_tx,
+                })
+                .is_err()
+            {
+                debug!("heartbeat: outgoing channel closed");
+                dead.store(true, Ordering::Relaxed);
+                return;
+            }
+
+            let res = timeout(PING_TIMEOUT, resp_rx).await;
+            match res {
+                Ok(Ok(Ok(_))) => {
+                    if consecutive_misses > 0 {
+                        debug!("heartbeat: recovered after {} misses", consecutive_misses);
+                    }
+                    consecutive_misses = 0;
+                }
+                _ => {
+                    consecutive_misses += 1;
+                    warn!(
+                        "heartbeat: ping miss {}/{}",
+                        consecutive_misses, MAX_MISSED_HEARTBEATS
+                    );
+                    if consecutive_misses >= MAX_MISSED_HEARTBEATS {
+                        warn!(
+                            "heartbeat: {} consecutive misses, marking RPC client dead",
+                            MAX_MISSED_HEARTBEATS
+                        );
+                        dead.store(true, Ordering::Relaxed);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Returns true if either:
+    /// - the background communication loop has exited (`sender.is_closed()`
+    ///   — underlying transport died), or
+    /// - the heartbeat task declared the far end unresponsive.
+    /// Cached clients that report `is_dead()` must be evicted and recreated
+    /// before the next request — otherwise every subsequent `send_request`
+    /// either fails instantly ("channel closed") or hangs until its 30s
+    /// timeout, repeatedly.
     pub fn is_dead(&self) -> bool {
-        self.sender.is_closed()
+        self.sender.is_closed() || self.dead.load(Ordering::Relaxed)
     }
 
     pub async fn send_request(&self, request: Request) -> Result<Response> {

--- a/src/remote/server.rs
+++ b/src/remote/server.rs
@@ -91,6 +91,22 @@ fn write_loop(receiver: Receiver<Message>) -> std::io::Result<()> {
     let mut buf = Vec::<u8>::new();
 
     for msg in receiver {
+        if let Message::Response(resp) = &msg {
+            let preview: String = resp
+                .result
+                .as_ref()
+                .map(|v| {
+                    let s = v.to_string();
+                    s[..s.len().min(512)].to_string()
+                })
+                .unwrap_or_else(|| "<none>".into());
+            debug!(
+                "remote-server write response id={:?} error={:?} result_preview={}",
+                resp.id,
+                resp.error.as_ref().map(|e| &e.message),
+                preview
+            );
+        }
         let envelope = match message_to_envelope(msg) {
             Ok(e) => e,
             Err(e) => {

--- a/src/remote/server.rs
+++ b/src/remote/server.rs
@@ -22,6 +22,66 @@ use crate::remote::rpc::{
     MessageLen, MESSAGE_LEN_SIZE,
 };
 
+/// Normalize a `file://~/path` URI sent by Emacs into a proper `file:///abs/path` URI.
+///
+/// The `url` crate parses `file://~/foo` with `~` as the hostname. On Unix,
+/// `Url::to_file_path()` rejects any non-empty host, so document lookup silently
+/// fails. We expand the tilde here, at the remote-server decode boundary, so the
+/// rest of the pipeline never sees the malformed form.
+fn normalize_tilde_uris(params: &mut Params) {
+    let home = std::env::var_os("HOME");
+    let home = home.as_deref();
+    normalize_uri_in_json_with_home(&mut params.params, home);
+    if let Some(ref mut uri) = params.uri {
+        *uri = normalize_tilde_uri_with_home(uri, home);
+    }
+}
+
+/// Accepts an explicit home dir so tests can be deterministic without touching env vars.
+fn normalize_tilde_uri_with_home(s: &str, home: Option<&std::ffi::OsStr>) -> String {
+    // Fast path: only consider file:// URIs that have ~ as host.
+    if !s.starts_with("file://~") {
+        return s.to_owned();
+    }
+    // file://~/rest  →  host = "~", path = "/rest"
+    // We want file:///home/user/rest
+    if let Ok(url) = lsp_types::Url::parse(s) {
+        if url.scheme() == "file" && url.host_str() == Some("~") {
+            if let Some(home) = home {
+                let mut abs = std::path::PathBuf::from(home);
+                // url.path() is "/rest" (starts with '/'), strip the leading '/'
+                abs.push(url.path().trim_start_matches('/'));
+                if let Ok(fixed) = lsp_types::Url::from_file_path(&abs) {
+                    return fixed.into();
+                }
+            }
+        }
+    }
+    s.to_owned()
+}
+
+fn normalize_uri_in_json_with_home(value: &mut serde_json::Value, home: Option<&std::ffi::OsStr>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, val) in map.iter_mut() {
+                if key == "uri" || key.ends_with("Uri") {
+                    if let serde_json::Value::String(s) = val {
+                        *s = normalize_tilde_uri_with_home(s, home);
+                    }
+                } else {
+                    normalize_uri_in_json_with_home(val, home);
+                }
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for val in arr {
+                normalize_uri_in_json_with_home(val, home);
+            }
+        }
+        _ => {}
+    }
+}
+
 const MAX_MESSAGE_LEN: u32 = 10 * 1024 * 1024;
 
 /// Build a [`Connection`] that speaks Envelope frames on stdio.
@@ -133,7 +193,8 @@ fn envelope_to_message(envelope: Envelope) -> Result<Message> {
         .ok_or_else(|| anyhow::anyhow!("envelope missing payload"))?;
     match payload {
         envelope::Payload::Request(req) => {
-            let params: Params = serde_json::from_slice(&req.params)?;
+            let mut params: Params = serde_json::from_slice(&req.params)?;
+            normalize_tilde_uris(&mut params);
             let id_numeric = envelope
                 .id
                 .ok_or_else(|| anyhow::anyhow!("request envelope missing id"))?;
@@ -144,7 +205,8 @@ fn envelope_to_message(envelope: Envelope) -> Result<Message> {
             }))
         }
         envelope::Payload::Notification(notif) => {
-            let params: Params = serde_json::from_slice(&notif.params)?;
+            let mut params: Params = serde_json::from_slice(&notif.params)?;
+            normalize_tilde_uris(&mut params);
             Ok(Message::Notification(Notification {
                 method: notif.method,
                 params,
@@ -315,5 +377,159 @@ mod tests {
             request_id_to_u32(&RequestId::from("abc".to_string())),
             None
         );
+    }
+
+    const FAKE_HOME: &str = "/home/user";
+
+    fn home() -> Option<&'static std::ffi::OsStr> {
+        Some(std::ffi::OsStr::new(FAKE_HOME))
+    }
+
+    #[test]
+    fn tilde_uri_expands_to_absolute() {
+        assert_eq!(
+            normalize_tilde_uri_with_home("file://~/foo/bar.rs", home()),
+            "file:///home/user/foo/bar.rs"
+        );
+    }
+
+    #[test]
+    fn tilde_uri_nested_path() {
+        assert_eq!(
+            normalize_tilde_uri_with_home(
+                "file://~/Documents/JadeStrong/demos/decode/src/client.js",
+                home()
+            ),
+            "file:///home/user/Documents/JadeStrong/demos/decode/src/client.js"
+        );
+    }
+
+    #[test]
+    fn absolute_uri_unchanged() {
+        let uri = "file:///absolute/path/file.rs";
+        assert_eq!(normalize_tilde_uri_with_home(uri, home()), uri);
+    }
+
+    #[test]
+    fn non_file_uri_unchanged() {
+        let uri = "untitled:Untitled-1";
+        assert_eq!(normalize_tilde_uri_with_home(uri, home()), uri);
+    }
+
+    #[test]
+    fn tilde_uri_without_home_unchanged() {
+        let uri = "file://~/foo.rs";
+        assert_eq!(normalize_tilde_uri_with_home(uri, None), uri);
+    }
+
+    #[test]
+    fn normalize_uri_in_json_fixes_text_document_uri() {
+        let mut json = serde_json::json!({
+            "textDocument": { "uri": "file://~/src/main.rs" }
+        });
+        normalize_uri_in_json_with_home(&mut json, home());
+        assert_eq!(
+            json["textDocument"]["uri"],
+            "file:///home/user/src/main.rs"
+        );
+    }
+
+    #[test]
+    fn normalize_uri_in_json_fixes_scope_uri() {
+        let mut json = serde_json::json!({ "scopeUri": "file://~/project" });
+        normalize_uri_in_json_with_home(&mut json, home());
+        assert_eq!(json["scopeUri"], "file:///home/user/project");
+    }
+
+    #[test]
+    fn normalize_uri_in_json_leaves_absolute_uris_unchanged() {
+        let mut json = serde_json::json!({
+            "textDocument": { "uri": "file:///already/absolute.rs" }
+        });
+        normalize_uri_in_json_with_home(&mut json, home());
+        assert_eq!(json["textDocument"]["uri"], "file:///already/absolute.rs");
+    }
+
+    #[test]
+    fn did_open_notification_envelope_normalizes_uri() {
+        let params = Params {
+            uri: Some("file://~/src/lib.rs".to_string()),
+            context: None,
+            virtual_doc: None,
+            params: serde_json::json!({
+                "textDocument": {
+                    "uri": "file://~/src/lib.rs",
+                    "languageId": "rust",
+                    "version": 0,
+                    "text": ""
+                }
+            }),
+        };
+        let envelope = Envelope {
+            id: None,
+            responding_to: None,
+            payload: Some(envelope::Payload::Notification(proto::Notification {
+                method: "textDocument/didOpen".into(),
+                params: serde_json::to_vec(&params).unwrap(),
+            })),
+        };
+
+        let msg = envelope_to_message(envelope).expect("decode");
+        match msg {
+            Message::Notification(n) => {
+                // top-level uri field is normalized
+                let uri = n.params.uri.as_deref().unwrap_or_default();
+                assert!(
+                    !uri.contains("//~"),
+                    "params.uri still contains tilde host: {uri}"
+                );
+                // textDocument.uri inside the JSON body is also normalized
+                let doc_uri = n.params.params["textDocument"]["uri"]
+                    .as_str()
+                    .unwrap_or_default();
+                assert!(
+                    !doc_uri.contains("//~"),
+                    "textDocument.uri still contains tilde host: {doc_uri}"
+                );
+            }
+            other => panic!("expected Notification, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn request_envelope_normalizes_uri() {
+        let params = Params {
+            uri: Some("file://~/project/main.rs".to_string()),
+            context: None,
+            virtual_doc: None,
+            params: serde_json::json!({
+                "textDocument": { "uri": "file://~/project/main.rs" },
+                "position": { "line": 10, "character": 5 }
+            }),
+        };
+        let envelope = Envelope {
+            id: Some(42),
+            responding_to: None,
+            payload: Some(envelope::Payload::Request(proto::Request {
+                method: "textDocument/definition".into(),
+                params: serde_json::to_vec(&params).unwrap(),
+            })),
+        };
+
+        let msg = envelope_to_message(envelope).expect("decode");
+        match msg {
+            Message::Request(req) => {
+                let uri = req.params.uri.as_deref().unwrap_or_default();
+                assert!(!uri.contains("//~"), "params.uri still has tilde: {uri}");
+                let doc_uri = req.params.params["textDocument"]["uri"]
+                    .as_str()
+                    .unwrap_or_default();
+                assert!(
+                    !doc_uri.contains("//~"),
+                    "textDocument.uri still has tilde: {doc_uri}"
+                );
+            }
+            other => panic!("expected Request, got {:?}", other),
+        }
     }
 }

--- a/src/remote/server.rs
+++ b/src/remote/server.rs
@@ -1,0 +1,303 @@
+//! Remote-server entry point.
+//!
+//! When lsp-proxy is launched with `--remote-server`, it speaks the Protobuf
+//! Envelope protocol on stdin/stdout instead of LSP JSON-RPC. Incoming
+//! Envelopes are translated to the internal `msg::Message` type so the normal
+//! `main_loop` + `Controller` can process them, and outgoing messages are
+//! re-encoded back into Envelopes for the SSH tunnel.
+
+use anyhow::Result;
+use crossbeam_channel::{bounded, Receiver, Sender};
+use log::{debug, error};
+use lsp_types::NumberOrString;
+use prost::Message as _;
+use std::io::{stdin, stdout, Read, Write};
+use std::thread;
+
+use crate::connection::{Connection, IoThreads};
+use crate::lsp::jsonrpc;
+use crate::msg::{Message, Notification, Params, Request, RequestId, Response};
+use crate::remote::rpc::{
+    proto::{self, envelope, Envelope, RpcError},
+    MessageLen, MESSAGE_LEN_SIZE,
+};
+
+const MAX_MESSAGE_LEN: u32 = 10 * 1024 * 1024;
+
+/// Build a [`Connection`] that speaks Envelope frames on stdio.
+///
+/// The returned `IoThreads` can be joined just like `Connection::stdio()`.
+pub fn envelope_stdio() -> (Connection, IoThreads) {
+    let (writer_sender, writer_receiver) = bounded::<Message>(0);
+    let (reader_sender, reader_receiver) = bounded::<Message>(0);
+
+    let writer = thread::spawn(move || write_loop(writer_receiver));
+    let reader = thread::spawn(move || read_loop(reader_sender));
+
+    (
+        Connection {
+            sender: writer_sender,
+            receiver: reader_receiver,
+        },
+        IoThreads::new(reader, writer),
+    )
+}
+
+fn read_loop(sender: Sender<Message>) -> std::io::Result<()> {
+    let mut stdin = stdin().lock();
+    let mut len_buf = [0u8; MESSAGE_LEN_SIZE];
+    let mut body = Vec::<u8>::new();
+
+    loop {
+        if let Err(e) = stdin.read_exact(&mut len_buf) {
+            if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                return Ok(());
+            }
+            return Err(e);
+        }
+        let len = MessageLen::from_le_bytes(len_buf);
+        if len == 0 || len > MAX_MESSAGE_LEN {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("invalid envelope length: {}", len),
+            ));
+        }
+        body.resize(len as usize, 0);
+        stdin.read_exact(&mut body)?;
+
+        let envelope = match Envelope::decode(body.as_slice()) {
+            Ok(e) => e,
+            Err(e) => {
+                error!("failed to decode envelope: {}", e);
+                continue;
+            }
+        };
+
+        match envelope_to_message(envelope) {
+            Ok(msg) => {
+                if sender.send(msg).is_err() {
+                    return Ok(());
+                }
+            }
+            Err(e) => {
+                debug!("ignoring undecodable envelope: {}", e);
+            }
+        }
+    }
+}
+
+fn write_loop(receiver: Receiver<Message>) -> std::io::Result<()> {
+    let mut stdout = stdout().lock();
+    let mut buf = Vec::<u8>::new();
+
+    for msg in receiver {
+        let envelope = match message_to_envelope(msg) {
+            Ok(e) => e,
+            Err(e) => {
+                error!("failed to encode outgoing message as envelope: {}", e);
+                continue;
+            }
+        };
+        let message_len = envelope.encoded_len() as u32;
+        stdout.write_all(&message_len.to_le_bytes())?;
+        buf.clear();
+        buf.reserve(message_len as usize);
+        envelope
+            .encode(&mut buf)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        stdout.write_all(&buf)?;
+        stdout.flush()?;
+    }
+    Ok(())
+}
+
+fn envelope_to_message(envelope: Envelope) -> Result<Message> {
+    let payload = envelope
+        .payload
+        .ok_or_else(|| anyhow::anyhow!("envelope missing payload"))?;
+    match payload {
+        envelope::Payload::Request(req) => {
+            let params: Params = serde_json::from_slice(&req.params)?;
+            let id_numeric = envelope
+                .id
+                .ok_or_else(|| anyhow::anyhow!("request envelope missing id"))?;
+            Ok(Message::Request(Request {
+                id: RequestId::from(id_numeric as i32),
+                method: req.method,
+                params,
+            }))
+        }
+        envelope::Payload::Notification(notif) => {
+            let params: Params = serde_json::from_slice(&notif.params)?;
+            Ok(Message::Notification(Notification {
+                method: notif.method,
+                params,
+            }))
+        }
+        envelope::Payload::Response(_) => {
+            Err(anyhow::anyhow!("server should not receive response payloads"))
+        }
+    }
+}
+
+fn message_to_envelope(msg: Message) -> Result<Envelope> {
+    match msg {
+        Message::Response(Response { id, result, error }) => {
+            let responding_to = request_id_to_u32(&id);
+            let result_bytes = match result {
+                Some(v) => Some(serde_json::to_vec(&v)?),
+                None => None,
+            };
+            let error = error.map(|e| RpcError {
+                code: e.code.code() as i32,
+                message: e.message,
+                data: e
+                    .data
+                    .as_ref()
+                    .and_then(|d| serde_json::to_vec(d).ok()),
+            });
+            Ok(Envelope {
+                id: None,
+                responding_to,
+                payload: Some(envelope::Payload::Response(proto::Response {
+                    result: result_bytes,
+                    error,
+                })),
+            })
+        }
+        Message::Notification(Notification { method, params }) => {
+            let params_bytes = serde_json::to_vec(&params)?;
+            Ok(Envelope {
+                id: None,
+                responding_to: None,
+                payload: Some(envelope::Payload::Notification(proto::Notification {
+                    method,
+                    params: params_bytes,
+                })),
+            })
+        }
+        Message::Request(Request { id, method, params }) => {
+            // Server-initiated requests. Use the numeric id if available,
+            // otherwise fall back to hashing/ignoring (strings aren't
+            // representable in the wire `id` field).
+            let params_bytes = serde_json::to_vec(&params)?;
+            Ok(Envelope {
+                id: request_id_to_u32(&id),
+                responding_to: None,
+                payload: Some(envelope::Payload::Request(proto::Request {
+                    method,
+                    params: params_bytes,
+                })),
+            })
+        }
+    }
+}
+
+fn request_id_to_u32(id: &RequestId) -> Option<u32> {
+    match NumberOrString::from(id.clone()) {
+        NumberOrString::Number(n) => Some(n as u32),
+        NumberOrString::String(_) => None,
+    }
+}
+
+// Silence unused-import lint on jsonrpc when feature flags change.
+#[allow(dead_code)]
+fn _use_jsonrpc(_e: &jsonrpc::Error) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_params(uri: &str) -> Params {
+        Params {
+            uri: Some(uri.to_string()),
+            context: None,
+            virtual_doc: None,
+            params: serde_json::json!({ "textDocument": { "uri": uri } }),
+        }
+    }
+
+    #[test]
+    fn envelope_request_round_trip() {
+        let envelope = Envelope {
+            id: Some(17),
+            responding_to: None,
+            payload: Some(envelope::Payload::Request(proto::Request {
+                method: "textDocument/definition".into(),
+                params: serde_json::to_vec(&make_params("file:///x.rs")).unwrap(),
+            })),
+        };
+
+        let msg = envelope_to_message(envelope).expect("decode");
+        match msg {
+            Message::Request(req) => {
+                assert_eq!(req.method, "textDocument/definition");
+                assert_eq!(req.id, RequestId::from(17));
+                assert_eq!(req.params.uri.as_deref(), Some("file:///x.rs"));
+            }
+            other => panic!("expected Request, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn response_message_encodes_responding_to() {
+        let msg = Message::Response(Response {
+            id: RequestId::from(21),
+            result: Some(serde_json::json!({"ok": true})),
+            error: None,
+        });
+        let env = message_to_envelope(msg).expect("encode");
+        assert_eq!(env.responding_to, Some(21));
+        match env.payload {
+            Some(envelope::Payload::Response(resp)) => {
+                let decoded: serde_json::Value =
+                    serde_json::from_slice(&resp.result.unwrap()).unwrap();
+                assert_eq!(decoded["ok"], true);
+                assert!(resp.error.is_none());
+            }
+            _ => panic!("expected Response payload"),
+        }
+    }
+
+    #[test]
+    fn notification_round_trip() {
+        let notif = Notification {
+            method: "window/logMessage".into(),
+            params: make_params("file:///foo.rs"),
+        };
+        let env = message_to_envelope(Message::Notification(notif.clone())).unwrap();
+        assert!(env.id.is_none() && env.responding_to.is_none());
+
+        let back = envelope_to_message(env).unwrap();
+        match back {
+            Message::Notification(n) => {
+                assert_eq!(n.method, notif.method);
+                assert_eq!(n.params.uri, notif.params.uri);
+            }
+            _ => panic!("expected Notification"),
+        }
+    }
+
+    #[test]
+    fn server_rejects_response_envelope() {
+        let env = Envelope {
+            id: None,
+            responding_to: Some(5),
+            payload: Some(envelope::Payload::Response(proto::Response {
+                result: None,
+                error: None,
+            })),
+        };
+        assert!(envelope_to_message(env).is_err());
+    }
+
+    #[test]
+    fn request_id_to_u32_handles_numbers_and_strings() {
+        assert_eq!(request_id_to_u32(&RequestId::from(0)), Some(0));
+        assert_eq!(request_id_to_u32(&RequestId::from(42)), Some(42));
+        assert_eq!(
+            request_id_to_u32(&RequestId::from("abc".to_string())),
+            None
+        );
+    }
+}

--- a/src/remote/server.rs
+++ b/src/remote/server.rs
@@ -59,7 +59,7 @@ fn read_loop(sender: Sender<Message>) -> std::io::Result<()> {
         if len == 0 || len > MAX_MESSAGE_LEN {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
-                format!("invalid envelope length: {}", len),
+                format!("invalid envelope length: {len}"),
             ));
         }
         body.resize(len as usize, 0);
@@ -68,7 +68,7 @@ fn read_loop(sender: Sender<Message>) -> std::io::Result<()> {
         let envelope = match Envelope::decode(body.as_slice()) {
             Ok(e) => e,
             Err(e) => {
-                error!("failed to decode envelope: {}", e);
+                error!("failed to decode envelope: {e}");
                 continue;
             }
         };
@@ -80,7 +80,7 @@ fn read_loop(sender: Sender<Message>) -> std::io::Result<()> {
                 }
             }
             Err(e) => {
-                debug!("ignoring undecodable envelope: {}", e);
+                debug!("ignoring undecodable envelope: {e}");
             }
         }
     }
@@ -110,7 +110,7 @@ fn write_loop(receiver: Receiver<Message>) -> std::io::Result<()> {
         let envelope = match message_to_envelope(msg) {
             Ok(e) => e,
             Err(e) => {
-                error!("failed to encode outgoing message as envelope: {}", e);
+                error!("failed to encode outgoing message as envelope: {e}");
                 continue;
             }
         };
@@ -120,7 +120,7 @@ fn write_loop(receiver: Receiver<Message>) -> std::io::Result<()> {
         buf.reserve(message_len as usize);
         envelope
             .encode(&mut buf)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            .map_err(std::io::Error::other)?;
         stdout.write_all(&buf)?;
         stdout.flush()?;
     }

--- a/src/remote/server.rs
+++ b/src/remote/server.rs
@@ -8,10 +8,12 @@
 
 use anyhow::Result;
 use crossbeam_channel::{bounded, Receiver, Sender};
-use log::{debug, error};
+use log::{debug, error, info};
 use lsp_types::NumberOrString;
 use prost::Message as _;
 use std::io::{stdin, stdout, Read, Write};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::thread;
 
 use crate::connection::{Connection, IoThreads};
@@ -87,12 +89,49 @@ const MAX_MESSAGE_LEN: u32 = 10 * 1024 * 1024;
 /// Build a [`Connection`] that speaks Envelope frames on stdio.
 ///
 /// The returned `IoThreads` can be joined just like `Connection::stdio()`.
+/// Idle timeout for the remote server: if no message arrives from the local
+/// lsp-proxy for this many seconds, assume the local process has died
+/// (e.g. Emacs killed it with SIGKILL) and exit.
+///
+/// The local side sends a heartbeat ping every 5 s with up to 5 misses before
+/// declaring the connection dead (≈ 25 s total).  We use 3× that window to
+/// avoid false positives while still cleaning up promptly.
+const IDLE_EXIT_SECS: u64 = 75;
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
 pub fn envelope_stdio() -> (Connection, IoThreads) {
     let (writer_sender, writer_receiver) = bounded::<Message>(0);
     let (reader_sender, reader_receiver) = bounded::<Message>(0);
 
+    // Shared timestamp updated by read_loop on every received envelope.
+    let last_msg = Arc::new(AtomicU64::new(now_secs()));
+
+    let last_msg_for_watchdog = last_msg.clone();
+    thread::Builder::new()
+        .name("remote-idle-watchdog".into())
+        .spawn(move || {
+            loop {
+                thread::sleep(std::time::Duration::from_secs(15));
+                let idle = now_secs().saturating_sub(last_msg_for_watchdog.load(Ordering::Relaxed));
+                if idle >= IDLE_EXIT_SECS {
+                    info!(
+                        "remote server idle for {idle}s (threshold {IDLE_EXIT_SECS}s), \
+                         local lsp-proxy likely dead — exiting"
+                    );
+                    std::process::exit(0);
+                }
+            }
+        })
+        .expect("spawn idle watchdog");
+
     let writer = thread::spawn(move || write_loop(writer_receiver));
-    let reader = thread::spawn(move || read_loop(reader_sender));
+    let reader = thread::spawn(move || read_loop(reader_sender, last_msg));
 
     (
         Connection {
@@ -103,7 +142,7 @@ pub fn envelope_stdio() -> (Connection, IoThreads) {
     )
 }
 
-fn read_loop(sender: Sender<Message>) -> std::io::Result<()> {
+fn read_loop(sender: Sender<Message>, last_msg: Arc<AtomicU64>) -> std::io::Result<()> {
     let mut stdin = stdin().lock();
     let mut len_buf = [0u8; MESSAGE_LEN_SIZE];
     let mut body = Vec::<u8>::new();
@@ -124,6 +163,9 @@ fn read_loop(sender: Sender<Message>) -> std::io::Result<()> {
         }
         body.resize(len as usize, 0);
         stdin.read_exact(&mut body)?;
+
+        // Reset the idle timer: local lsp-proxy is still alive.
+        last_msg.store(now_secs(), Ordering::Relaxed);
 
         let envelope = match Envelope::decode(body.as_slice()) {
             Ok(e) => e,

--- a/src/remote/server.rs
+++ b/src/remote/server.rs
@@ -297,9 +297,14 @@ fn message_to_envelope(msg: Message) -> Result<Envelope> {
             })
         }
         Message::Request(Request { id, method, params }) => {
-            // Server-initiated requests. Use the numeric id if available,
-            // otherwise fall back to hashing/ignoring (strings aren't
-            // representable in the wire `id` field).
+            // Server-initiated requests (e.g. window/showMessageRequest).
+            // TODO: String request IDs are not representable in the wire `id`
+            // field (u32), so they are silently dropped here (envelope.id =
+            // None).  The receiver (rpc.rs decode_server_request) will then
+            // discard the entire message and the LSP server will never get a
+            // response, potentially causing it to stall or time out.  A proper
+            // fix would maintain a HashMap<u32, RequestId> to round-trip
+            // arbitrary IDs (e.g. by hashing the string to a u32 key).
             let params_bytes = serde_json::to_vec(&params)?;
             Ok(Envelope {
                 id: request_id_to_u32(&id),

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -136,6 +136,24 @@ struct MasterProcess {
     destination: String,
 }
 
+impl Drop for MasterProcess {
+    fn drop(&mut self) {
+        // Dropping a tokio Child does NOT kill the process; we must do it
+        // explicitly so that all muxed sessions (including remote
+        // `emacs-lsp-proxy --remote-server` processes) receive SIGHUP and
+        // exit when lsp-proxy restarts or a connection is evicted.
+        //
+        // `start_kill()` is synchronous (SIGKILL, no await needed) and safe
+        // to call from any context, including outside the tokio runtime.
+        // We intentionally avoid `tokio::spawn` here — Drop can be invoked
+        // after the runtime has shut down, and spawn would panic in that case.
+        let _ = self.process.start_kill();
+
+        #[cfg(not(target_os = "windows"))]
+        let _ = std::fs::remove_file(&self.socket_path);
+    }
+}
+
 impl MasterProcess {
     #[cfg(not(target_os = "windows"))]
     pub async fn new(
@@ -616,7 +634,12 @@ impl SshConnection {
             .arg(&command)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped());
+            .stderr(std::process::Stdio::piped())
+            // When the Child is dropped (together with SshRpcStream / RpcClient),
+            // automatically send SIGKILL to the local SSH slave so the remote
+            // process loses its connection and exits before the ControlMaster
+            // is torn down.
+            .kill_on_drop(true);
 
         info!("Starting remote LSP proxy: {command}");
         let mut process = cmd.spawn().context("Failed to spawn remote LSP proxy")?;
@@ -668,7 +691,7 @@ impl SshConnection {
 /// SSH LSP进程包装
 #[allow(dead_code)]
 pub struct SshLspProcess {
-    process: Child,
+    pub process: Child,
     pub stdin: tokio::process::ChildStdin,
     pub stdout: tokio::process::ChildStdout,
 }

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -651,50 +651,6 @@ impl SshConnection {
         })
     }
 
-    /// Copy a local file to a remote path via `scp`, reusing the SSH
-    /// ControlMaster socket for zero-handshake transfer. Caller should ensure
-    /// the parent directory exists (use [`run_command`] with `mkdir -p`).
-    pub async fn scp_upload(&self, local_path: &std::path::Path, remote_path: &str) -> Result<()> {
-        self.ensure_master_connection().await?;
-
-        let mut cmd = Command::new("scp");
-        #[cfg(not(target_os = "windows"))]
-        cmd.arg("-o")
-            .arg(format!("ControlPath={}", self.socket.socket_path.display()));
-        cmd.arg("-o")
-            .arg("ControlMaster=no")
-            // scp auto-infers no-TTY, but LogLevel + RemoteCommand overrides
-            // still help suppress spurious host config behaviour.
-            .arg("-o")
-            .arg("LogLevel=ERROR")
-            .arg("-o")
-            .arg("RemoteCommand=none")
-            .args(self.socket.connection_options.port_args())
-            .arg(local_path)
-            .arg(format!(
-                "{}:{}",
-                self.socket.connection_options.destination(),
-                remote_path
-            ));
-
-        debug!(
-            "scp {} -> {}:{}",
-            local_path.display(),
-            self.socket.connection_options.destination(),
-            remote_path
-        );
-        let output = cmd.output().await.context("scp failed to launch")?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow!(
-                "scp upload failed (exit {}): {}",
-                output.status,
-                stderr.trim()
-            ));
-        }
-        Ok(())
-    }
-
     pub async fn start_remote_lsp_proxy(&self, remote_path: &str) -> Result<SshLspProcess> {
         self.ensure_master_connection().await?;
 

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -163,12 +163,17 @@ impl MasterProcess {
     ) -> Result<Self> {
         let args = [
             "-N",
-            // ControlPersist=yes keeps the master alive in the background
-            // after startup. With `ControlPersist=no` the master would exit
-            // as soon as its "initial client" (which with -N doesn't exist)
-            // would have closed — effectively making it exit immediately.
+            // ControlPersist=600 keeps the master alive for up to 600 seconds
+            // (10 minutes) after the last mux client disconnects.  This serves
+            // as an automatic cleanup fallback: when lsp-proxy is killed without
+            // running its exit hook (e.g. SIGKILL from the OS), the ControlMaster
+            // will eventually idle out, close its TCP connection with a proper
+            // FIN, and the remote sshd will cleanly EOF the remote process's
+            // stdin — causing emacs-lsp-proxy --remote-server to exit on its own.
+            // "yes" would keep it alive indefinitely, which leaks the remote
+            // process forever in that scenario.
             "-o",
-            "ControlPersist=yes",
+            "ControlPersist=600",
             "-o",
             "ControlMaster=yes",
             // Keepalive: send an SSH-level probe every 15s; if 3 go
@@ -257,7 +262,7 @@ impl MasterProcess {
     #[cfg(not(target_os = "windows"))]
     pub async fn wait_connected(&mut self) -> Result<()> {
         let deadline = std::time::Instant::now() + MASTER_READY_TIMEOUT;
-        // With ControlPersist=yes, ssh forks a background daemon and the
+        // With ControlPersist=<seconds>, ssh forks a background daemon and the
         // foreground process exits 0 almost immediately. That's expected —
         // the real master lives on via the control socket. Treat exit 0 as
         // "daemonised successfully" and keep polling; only non-zero exits

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -571,12 +571,19 @@ impl SshConnection {
             .get()
             .copied()
             .unwrap_or(20);
-        let mut command = format!(
+        let mut inner = format!(
             "{remote_path} --remote-server --max-item {max_items}"
         );
         if log_level > 0 {
-            command.push_str(&format!(" --log-level {log_level}"));
+            inner.push_str(&format!(" --log-level {log_level}"));
         }
+
+        // Execute the remote binary directly.  The binary itself calls
+        // `load_login_shell_env()` at startup to capture and apply the login
+        // shell's environment (PATH, nvm, Homebrew, etc.), so we do not need
+        // any shell wrapper here.  Avoiding a wrapper removes all shell syntax
+        // compatibility issues (bash vs fish vs zsh) and stdout-pollution risk.
+        let command = inner;
 
         let mut cmd = Command::new("ssh");
 

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -1,13 +1,13 @@
-use anyhow::{Result, anyhow, Context};
+use anyhow::{anyhow, Context, Result};
 use log::{debug, error, info, warn};
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::process::{Child, Command};
-use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::Mutex;
 use tempfile::TempDir;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::process::{Child, Command};
+use tokio::sync::Mutex;
 
 use super::RemoteHost;
 
@@ -77,7 +77,11 @@ impl SshConnectionOptions {
     pub fn new(host: String, username: String) -> Self {
         // Empty username means "let ssh resolve via ~/.ssh/config", which is
         // the common case with SSH aliases like `Host home\n  User me`.
-        let username = if username.is_empty() { None } else { Some(username) };
+        let username = if username.is_empty() {
+            None
+        } else {
+            Some(username)
+        };
         Self {
             host: host.into(),
             username,
@@ -251,10 +255,7 @@ impl MasterProcess {
             if self.socket_path.exists()
                 && ssh_check_master(&self.socket_path, &self.destination).await?
             {
-                info!(
-                    "SSH master ready (socket {})",
-                    self.socket_path.display()
-                );
+                info!("SSH master ready (socket {})", self.socket_path.display());
                 return Ok(());
             }
 
@@ -290,10 +291,7 @@ impl MasterProcess {
 
         loop {
             if let Some(status) = self.process.try_wait()? {
-                return Err(anyhow!(
-                    "SSH master exited early with status {}",
-                    status
-                ));
+                return Err(anyhow!("SSH master exited early with status {}", status));
             }
 
             let remaining = deadline.saturating_duration_since(std::time::Instant::now());
@@ -337,10 +335,7 @@ impl MasterProcess {
 
 /// Verify the ssh master at `socket_path` is still responsive.
 #[cfg(not(target_os = "windows"))]
-async fn ssh_check_master(
-    socket_path: &std::path::Path,
-    destination: &str,
-) -> Result<bool> {
+async fn ssh_check_master(socket_path: &std::path::Path, destination: &str) -> Result<bool> {
     let output = Command::new("ssh")
         .arg("-o")
         .arg(format!("ControlPath={}", socket_path.display()))
@@ -444,13 +439,17 @@ impl SshConnection {
 
         if master_guard.is_none() {
             let destination = self.socket.connection_options.destination();
-            let additional_args = self.socket.connection_options.args
+            let additional_args = self
+                .socket
+                .connection_options
+                .args
                 .as_ref()
                 .cloned()
                 .unwrap_or_default();
 
             #[cfg(not(target_os = "windows"))]
-            let master = MasterProcess::new(&self.socket.socket_path, &destination, additional_args).await?;
+            let master =
+                MasterProcess::new(&self.socket.socket_path, &destination, additional_args).await?;
 
             #[cfg(target_os = "windows")]
             let master = MasterProcess::new(&destination, additional_args).await?;
@@ -509,11 +508,7 @@ impl SshConnection {
     /// Copy a local file to a remote path via `scp`, reusing the SSH
     /// ControlMaster socket for zero-handshake transfer. Caller should ensure
     /// the parent directory exists (use [`run_command`] with `mkdir -p`).
-    pub async fn scp_upload(
-        &self,
-        local_path: &std::path::Path,
-        remote_path: &str,
-    ) -> Result<()> {
+    pub async fn scp_upload(&self, local_path: &std::path::Path, remote_path: &str) -> Result<()> {
         self.ensure_master_connection().await?;
 
         let mut cmd = Command::new("scp");
@@ -558,7 +553,14 @@ impl SshConnection {
 
         // 构造启动远程LSP代理的命令。远程端必须使用 --remote-server 模式,
         // 这样 stdio 上走的是 Protobuf Envelope 协议,与本地 RpcClient 对齐。
-        let command = format!("{} --remote-server", remote_path);
+        // 把本地的 log-level 透传过去,远端才会写出有内容的 log
+        // (默认落在远端 binary 所在目录下的 `remote-server.log`)。
+        let log_level = crate::config::log_level();
+        let command = if log_level > 0 {
+            format!("{} --remote-server --log-level {}", remote_path, log_level)
+        } else {
+            format!("{} --remote-server", remote_path)
+        };
 
         let mut cmd = Command::new("ssh");
 
@@ -588,8 +590,14 @@ impl SshConnection {
         info!("Starting remote LSP proxy: {}", command);
         let mut process = cmd.spawn().context("Failed to spawn remote LSP proxy")?;
 
-        let stdin = process.stdin.take().ok_or_else(|| anyhow!("Failed to get stdin"))?;
-        let stdout = process.stdout.take().ok_or_else(|| anyhow!("Failed to get stdout"))?;
+        let stdin = process
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow!("Failed to get stdin"))?;
+        let stdout = process
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("Failed to get stdout"))?;
 
         Ok(SshLspProcess {
             process,
@@ -612,11 +620,16 @@ pub struct SshLspProcess {
 
 impl SshLspProcess {
     pub async fn wait(&mut self) -> Result<std::process::ExitStatus> {
-        self.process.wait().await.context("SSH LSP process wait failed")
+        self.process
+            .wait()
+            .await
+            .context("SSH LSP process wait failed")
     }
 
     pub fn kill(&mut self) -> Result<()> {
-        self.process.start_kill().context("Failed to kill SSH LSP process")
+        self.process
+            .start_kill()
+            .context("Failed to kill SSH LSP process")
     }
 }
 
@@ -653,10 +666,7 @@ mod tests {
     async fn ssh_check_master_returns_false_for_missing_socket() {
         // Pointing at a socket that doesn't exist must surface as "not alive"
         // rather than panicking or hanging.
-        let tmp = std::env::temp_dir().join(format!(
-            "lsp-proxy-ssh-test-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let tmp = std::env::temp_dir().join(format!("lsp-proxy-ssh-test-{}", uuid::Uuid::new_v4()));
         assert!(!tmp.exists());
         let alive = ssh_check_master(&tmp, "nobody@nowhere.invalid")
             .await
@@ -679,8 +689,8 @@ mod tests {
             .spawn()
             .expect("spawn test master");
 
-        let socket_path = std::env::temp_dir()
-            .join(format!("lsp-proxy-ssh-test-{}", uuid::Uuid::new_v4()));
+        let socket_path =
+            std::env::temp_dir().join(format!("lsp-proxy-ssh-test-{}", uuid::Uuid::new_v4()));
         let mut master = MasterProcess {
             process: child,
             socket_path,

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -444,6 +444,76 @@ pub struct SshConnection {
 }
 
 impl SshConnection {
+    /// Kill the SSH ControlMaster process synchronously without async/await.
+    ///
+    /// Called from `kill_all_sync` (a synchronous shutdown path) just before
+    /// `process::exit()`.  Killing the master causes all muxed sessions to
+    /// receive SIGHUP, which terminates the remote `emacs-lsp-proxy --remote-server`
+    /// processes.  Uses `try_lock` — if the lock is held the kill is skipped,
+    /// but the `MasterProcess::drop` impl will still fire later when the Arc
+    /// is released.
+    pub fn kill_master_sync(&self) {
+        if let Ok(mut guard) = self.master_process.try_lock() {
+            if let Some(ref mut mp) = *guard {
+                #[cfg(not(target_os = "windows"))]
+                {
+                    let socket = mp.socket_path.to_string_lossy();
+                    let ssh_args_base = [
+                        "-S", &socket,
+                        "-o", "ControlMaster=no",
+                        "-T",
+                        "-o", "LogLevel=ERROR",
+                        "-o", "BatchMode=yes",
+                        &mp.destination,
+                    ];
+
+                    // Step 1: Directly kill the remote emacs-lsp-proxy process
+                    // via the existing ControlMaster connection.
+                    //
+                    // On macOS, the remote host does not have a PTY (we use -T),
+                    // so sshd never sends SIGHUP to the remote process group when
+                    // the connection drops.  TCP RST also does not reliably close
+                    // the remote process's stdin on macOS — it can survive for
+                    // hours waiting for TCP keepalive to expire.  The only
+                    // guaranteed fix is to kill it directly over SSH.
+                    let kill_result = std::process::Command::new("ssh")
+                        .args(ssh_args_base)
+                        .arg("pkill -TERM -f 'emacs-lsp-proxy.*--remote-server'; true")
+                        .output();
+                    match kill_result {
+                        Ok(_) => info!("sent SIGTERM to remote emacs-lsp-proxy on {}", mp.destination),
+                        Err(e) => warn!("could not send SIGTERM to remote on {}: {e}", mp.destination),
+                    }
+
+                    // Step 2: Gracefully close the ControlMaster so it sends
+                    // proper SSH disconnect messages.
+                    let exit_result = std::process::Command::new("ssh")
+                        .args(["-S", &socket, "-O", "exit", "-o", "LogLevel=ERROR", &mp.destination])
+                        .output();
+                    match exit_result {
+                        Ok(out) if out.status.success() => {
+                            info!("ssh -O exit succeeded for {}", mp.destination);
+                        }
+                        Ok(out) => warn!(
+                            "ssh -O exit failed for {} (exit={:?}): {}",
+                            mp.destination, out.status.code(),
+                            String::from_utf8_lossy(&out.stderr).trim()
+                        ),
+                        Err(e) => warn!("ssh -O exit could not run for {}: {e}", mp.destination),
+                    }
+                }
+
+                // Fallback / belt-and-suspenders: SIGKILL the master process.
+                // If `ssh -O exit` already caused it to exit this is a no-op.
+                let _ = mp.process.start_kill();
+
+                #[cfg(not(target_os = "windows"))]
+                let _ = std::fs::remove_file(&mp.socket_path);
+            }
+            *guard = None;
+        }
+    }
+
     pub async fn connect(options: SshConnectionOptions) -> Result<Self> {
         let socket = SshSocket::new(options.clone())?;
         let temp_dir = tempfile::tempdir().context("Failed to create temp directory")?;

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -607,6 +607,28 @@ impl SshConnection {
             .stdout
             .take()
             .ok_or_else(|| anyhow!("Failed to get stdout"))?;
+        // Surface the remote process's stderr into our log so that when ssh
+        // or the remote binary dies (bad arg, not-executable, gatekeeper,
+        // missing LD libs) we can see WHY instead of just "RPC channel closed".
+        if let Some(stderr) = process.stderr.take() {
+            tokio::spawn(async move {
+                use tokio::io::{AsyncBufReadExt, BufReader};
+                let mut lines = BufReader::new(stderr).lines();
+                loop {
+                    match lines.next_line().await {
+                        Ok(Some(line)) => warn!("[remote stderr] {}", line),
+                        Ok(None) => {
+                            debug!("[remote stderr] EOF");
+                            break;
+                        }
+                        Err(e) => {
+                            warn!("[remote stderr] read error: {}", e);
+                            break;
+                        }
+                    }
+                }
+            });
+        }
 
         Ok(SshLspProcess {
             process,

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -1,0 +1,637 @@
+use anyhow::{Result, anyhow, Context};
+use log::{debug, error, info, warn};
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::process::{Child, Command};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::Mutex;
+use tempfile::TempDir;
+
+use super::RemoteHost;
+
+/// Result of a remote command, preserving the exit code so callers can tell
+/// "binary not found" (non-zero exit) from "transport failure" (error on the
+/// Result).
+#[derive(Debug, Clone)]
+pub struct CommandOutput {
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl CommandOutput {
+    pub fn is_success(&self) -> bool {
+        self.exit_code == Some(0)
+    }
+}
+
+/// SSH连接主机类型
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SshConnectionHost {
+    IpAddr(IpAddr),
+    Hostname(String),
+}
+
+impl SshConnectionHost {
+    pub fn to_string(&self) -> String {
+        match self {
+            Self::IpAddr(ip) => ip.to_string(),
+            Self::Hostname(hostname) => hostname.clone(),
+        }
+    }
+}
+
+impl From<&str> for SshConnectionHost {
+    fn from(value: &str) -> Self {
+        if let Ok(address) = value.parse() {
+            Self::IpAddr(address)
+        } else {
+            Self::Hostname(value.to_string())
+        }
+    }
+}
+
+impl From<String> for SshConnectionHost {
+    fn from(value: String) -> Self {
+        if let Ok(address) = value.parse() {
+            Self::IpAddr(address)
+        } else {
+            Self::Hostname(value)
+        }
+    }
+}
+
+/// SSH连接选项
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SshConnectionOptions {
+    pub host: SshConnectionHost,
+    pub username: Option<String>,
+    pub port: Option<u16>,
+    pub args: Option<Vec<String>>,
+    pub connection_timeout: Option<u16>,
+}
+
+impl SshConnectionOptions {
+    pub fn new(host: String, username: String) -> Self {
+        Self {
+            host: host.into(),
+            username: Some(username),
+            port: None,
+            args: None,
+            connection_timeout: Some(30),
+        }
+    }
+
+    pub fn with_port(mut self, port: u16) -> Self {
+        self.port = Some(port);
+        self
+    }
+
+    pub fn destination(&self) -> String {
+        let host_str = self.host.to_string();
+        match &self.username {
+            Some(username) => format!("{}@{}", username, host_str),
+            None => host_str,
+        }
+    }
+
+    pub fn connection_key(&self) -> String {
+        match self.port {
+            Some(port) => format!("{}:{}", self.destination(), port),
+            None => self.destination(),
+        }
+    }
+}
+
+/// SSH Socket封装
+struct SshSocket {
+    connection_options: SshConnectionOptions,
+    #[cfg(not(target_os = "windows"))]
+    socket_path: PathBuf,
+    envs: HashMap<String, String>,
+}
+
+/// Maximum time we wait for the SSH master to become ready (socket present
+/// and `ssh -O check` succeeds).
+const MASTER_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+/// How often we poll for readiness. Keeping this short makes the happy path
+/// (local or cached-key SSH targets) feel instant.
+const MASTER_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+
+/// SSH 主连接进程。持有启动的 ssh master 子进程,以及为就绪探测所需的元数据。
+struct MasterProcess {
+    process: Child,
+    #[cfg(not(target_os = "windows"))]
+    socket_path: std::path::PathBuf,
+    #[cfg(not(target_os = "windows"))]
+    destination: String,
+}
+
+impl MasterProcess {
+    #[cfg(not(target_os = "windows"))]
+    pub async fn new(
+        socket_path: &std::path::Path,
+        destination: &str,
+        additional_args: Vec<String>,
+    ) -> Result<Self> {
+        let args = [
+            "-N",
+            "-o",
+            "ControlPersist=no",
+            "-o",
+            "ControlMaster=yes",
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+        ];
+
+        let mut master_process = Command::new("ssh");
+        master_process
+            .kill_on_drop(true)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .args(&args)
+            .args(&additional_args)
+            .arg("-o")
+            .arg(format!("ControlPath={}", socket_path.display()))
+            .arg(destination);
+
+        debug!("Starting SSH master process: ssh {}", destination);
+        let process = master_process
+            .spawn()
+            .context("Failed to spawn SSH master process")?;
+
+        Ok(MasterProcess {
+            process,
+            socket_path: socket_path.to_path_buf(),
+            destination: destination.to_string(),
+        })
+    }
+
+    #[cfg(target_os = "windows")]
+    pub async fn new(destination: &str, additional_args: Vec<String>) -> Result<Self> {
+        // Windows 不走 ControlMaster,仍保留一个 echo 标记后 sleep 的长连接占位。
+        let args = [
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=NUL",
+        ];
+
+        let mut master_process = Command::new("ssh");
+        master_process
+            .kill_on_drop(true)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .args(&args)
+            .args(&additional_args)
+            .arg(destination)
+            .arg("echo SSH_CONNECTION_ESTABLISHED; sleep 3600");
+
+        debug!("Starting SSH master process: ssh {}", destination);
+        let process = master_process
+            .spawn()
+            .context("Failed to spawn SSH master process")?;
+
+        Ok(MasterProcess { process })
+    }
+
+    /// Wait until the SSH master is actually usable, not just started.
+    ///
+    /// Unix: poll for the control socket file, then verify the master is alive
+    /// with `ssh -O check`. Bail immediately if the master process exits early
+    /// (surfacing its stderr to make auth/host errors debuggable).
+    ///
+    /// Windows: wait for the marker string on stdout, since there's no control
+    /// socket to probe.
+    #[cfg(not(target_os = "windows"))]
+    pub async fn wait_connected(&mut self) -> Result<()> {
+        let deadline = std::time::Instant::now() + MASTER_READY_TIMEOUT;
+
+        loop {
+            if let Some(status) = self.process.try_wait()? {
+                let stderr_msg = self.drain_stderr().await;
+                return Err(anyhow!(
+                    "SSH master exited early with status {}: {}",
+                    status,
+                    stderr_msg.trim()
+                ));
+            }
+
+            if self.socket_path.exists()
+                && ssh_check_master(&self.socket_path, &self.destination).await?
+            {
+                info!(
+                    "SSH master ready (socket {})",
+                    self.socket_path.display()
+                );
+                return Ok(());
+            }
+
+            if std::time::Instant::now() >= deadline {
+                return Err(anyhow!(
+                    "SSH master not ready within {:?} (socket {} never responded)",
+                    MASTER_READY_TIMEOUT,
+                    self.socket_path.display()
+                ));
+            }
+
+            tokio::time::sleep(MASTER_POLL_INTERVAL).await;
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    pub async fn wait_connected(&mut self) -> Result<()> {
+        use tokio::io::{AsyncBufReadExt, BufReader};
+
+        let deadline = std::time::Instant::now() + MASTER_READY_TIMEOUT;
+        let Some(stdout) = self.process.stdout.take() else {
+            return Err(anyhow!("SSH master has no captured stdout to monitor"));
+        };
+        let mut lines = BufReader::new(stdout).lines();
+
+        loop {
+            if let Some(status) = self.process.try_wait()? {
+                return Err(anyhow!(
+                    "SSH master exited early with status {}",
+                    status
+                ));
+            }
+
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                return Err(anyhow!(
+                    "SSH master did not emit readiness marker within {:?}",
+                    MASTER_READY_TIMEOUT
+                ));
+            }
+
+            match tokio::time::timeout(remaining, lines.next_line()).await {
+                Ok(Ok(Some(line))) if line.contains("SSH_CONNECTION_ESTABLISHED") => {
+                    info!("SSH master ready (saw readiness marker)");
+                    return Ok(());
+                }
+                Ok(Ok(Some(_))) => continue,
+                Ok(Ok(None)) => {
+                    return Err(anyhow!("SSH master stdout closed before readiness marker"));
+                }
+                Ok(Err(e)) => return Err(anyhow!("error reading SSH master stdout: {}", e)),
+                Err(_) => {} // tick around the outer loop so we can recheck try_wait
+            }
+        }
+    }
+
+    /// Non-blocking best-effort drain of the master's stderr. Called only
+    /// after the process has already exited, so reading to EOF is safe.
+    async fn drain_stderr(&mut self) -> String {
+        let Some(mut stderr) = self.process.stderr.take() else {
+            return String::new();
+        };
+        let mut buf = Vec::new();
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_millis(200),
+            tokio::io::AsyncReadExt::read_to_end(&mut stderr, &mut buf),
+        )
+        .await;
+        String::from_utf8_lossy(&buf).into_owned()
+    }
+}
+
+/// Verify the ssh master at `socket_path` is still responsive.
+#[cfg(not(target_os = "windows"))]
+async fn ssh_check_master(
+    socket_path: &std::path::Path,
+    destination: &str,
+) -> Result<bool> {
+    let output = Command::new("ssh")
+        .arg("-o")
+        .arg(format!("ControlPath={}", socket_path.display()))
+        .arg("-O")
+        .arg("check")
+        .arg(destination)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .await
+        .context("Failed to run `ssh -O check`")?;
+    Ok(output.status.success())
+}
+
+impl SshSocket {
+    pub fn new(connection_options: SshConnectionOptions) -> Result<Self> {
+        #[cfg(not(target_os = "windows"))]
+        let socket_path = {
+            let temp_dir = std::env::temp_dir();
+            temp_dir.join(format!("lsp-proxy-ssh-{}", uuid::Uuid::new_v4()))
+        };
+
+        let envs = HashMap::new();
+
+        Ok(Self {
+            connection_options,
+            #[cfg(not(target_os = "windows"))]
+            socket_path,
+            envs,
+        })
+    }
+
+    pub async fn ssh_command(&self, command: &str) -> Result<Vec<u8>> {
+        let mut cmd = Command::new("ssh");
+
+        #[cfg(not(target_os = "windows"))]
+        cmd.arg("-o")
+            .arg(format!("ControlPath={}", self.socket_path.display()));
+
+        cmd.arg("-o")
+            .arg("ControlMaster=no")
+            .arg(self.connection_options.destination())
+            .arg(command);
+
+        debug!("Executing SSH command: {}", command);
+        let output = cmd.output().await?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow!("SSH command failed: {}", stderr));
+        }
+
+        Ok(output.stdout)
+    }
+}
+
+/// SSH连接管理器
+pub struct SshConnection {
+    socket: SshSocket,
+    master_process: Arc<Mutex<Option<MasterProcess>>>,
+    _temp_dir: TempDir,
+}
+
+impl SshConnection {
+    pub async fn connect(options: SshConnectionOptions) -> Result<Self> {
+        let socket = SshSocket::new(options.clone())?;
+        let temp_dir = tempfile::tempdir().context("Failed to create temp directory")?;
+
+        let connection = Self {
+            socket,
+            master_process: Arc::new(Mutex::new(None)),
+            _temp_dir: temp_dir,
+        };
+
+        // 建立SSH主连接
+        connection.ensure_master_connection().await?;
+
+        Ok(connection)
+    }
+
+    async fn ensure_master_connection(&self) -> Result<()> {
+        let mut master_guard = self.master_process.lock().await;
+
+        if master_guard.is_none() {
+            let destination = self.socket.connection_options.destination();
+            let additional_args = self.socket.connection_options.args
+                .as_ref()
+                .cloned()
+                .unwrap_or_default();
+
+            #[cfg(not(target_os = "windows"))]
+            let master = MasterProcess::new(&self.socket.socket_path, &destination, additional_args).await?;
+
+            #[cfg(target_os = "windows")]
+            let master = MasterProcess::new(&destination, additional_args).await?;
+
+            *master_guard = Some(master);
+        }
+
+        if let Some(master) = master_guard.as_mut() {
+            master.wait_connected().await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn run_command(&self, command: &str) -> Result<String> {
+        self.ensure_master_connection().await?;
+
+        let output = self.socket.ssh_command(command).await?;
+        let result = String::from_utf8(output).context("Invalid UTF-8 in command output")?;
+
+        debug!("SSH command result: {}", result.trim());
+        Ok(result)
+    }
+
+    /// Run a command on the remote host and return the full exit details.
+    ///
+    /// Unlike [`run_command`], this does NOT treat a non-zero exit code as an
+    /// error — callers who care about e.g. "binary not found" (exit 127)
+    /// versus "ssh transport failed" need that distinction.
+    pub async fn run_command_with_status(&self, command: &str) -> Result<CommandOutput> {
+        self.ensure_master_connection().await?;
+
+        let mut cmd = Command::new("ssh");
+        #[cfg(not(target_os = "windows"))]
+        cmd.arg("-o")
+            .arg(format!("ControlPath={}", self.socket.socket_path.display()));
+        cmd.arg("-o")
+            .arg("ControlMaster=no")
+            .arg(self.socket.connection_options.destination())
+            .arg(command);
+
+        debug!("Executing SSH command (with status): {}", command);
+        let output = cmd.output().await.context("ssh command failed to launch")?;
+        Ok(CommandOutput {
+            exit_code: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        })
+    }
+
+    /// Copy a local file to a remote path via `scp`, reusing the SSH
+    /// ControlMaster socket for zero-handshake transfer. Caller should ensure
+    /// the parent directory exists (use [`run_command`] with `mkdir -p`).
+    pub async fn scp_upload(
+        &self,
+        local_path: &std::path::Path,
+        remote_path: &str,
+    ) -> Result<()> {
+        self.ensure_master_connection().await?;
+
+        let mut cmd = Command::new("scp");
+        #[cfg(not(target_os = "windows"))]
+        cmd.arg("-o")
+            .arg(format!("ControlPath={}", self.socket.socket_path.display()));
+        cmd.arg("-o")
+            .arg("ControlMaster=no")
+            .arg(local_path)
+            .arg(format!(
+                "{}:{}",
+                self.socket.connection_options.destination(),
+                remote_path
+            ));
+
+        debug!(
+            "scp {} -> {}:{}",
+            local_path.display(),
+            self.socket.connection_options.destination(),
+            remote_path
+        );
+        let output = cmd.output().await.context("scp failed to launch")?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow!(
+                "scp upload failed (exit {}): {}",
+                output.status,
+                stderr.trim()
+            ));
+        }
+        Ok(())
+    }
+
+    pub async fn start_remote_lsp_proxy(&self, remote_path: &str) -> Result<SshLspProcess> {
+        self.ensure_master_connection().await?;
+
+        // 构造启动远程LSP代理的命令。远程端必须使用 --remote-server 模式,
+        // 这样 stdio 上走的是 Protobuf Envelope 协议,与本地 RpcClient 对齐。
+        let command = format!("{} --remote-server", remote_path);
+
+        let mut cmd = Command::new("ssh");
+
+        #[cfg(not(target_os = "windows"))]
+        cmd.arg("-o")
+            .arg(format!("ControlPath={}", self.socket.socket_path.display()));
+
+        cmd.arg("-o")
+            .arg("ControlMaster=no")
+            .arg(self.socket.connection_options.destination())
+            .arg(&command)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+
+        info!("Starting remote LSP proxy: {}", command);
+        let mut process = cmd.spawn().context("Failed to spawn remote LSP proxy")?;
+
+        let stdin = process.stdin.take().ok_or_else(|| anyhow!("Failed to get stdin"))?;
+        let stdout = process.stdout.take().ok_or_else(|| anyhow!("Failed to get stdout"))?;
+
+        Ok(SshLspProcess {
+            process,
+            stdin,
+            stdout,
+        })
+    }
+
+    pub fn connection_key(&self) -> String {
+        self.socket.connection_options.connection_key()
+    }
+}
+
+/// SSH LSP进程包装
+pub struct SshLspProcess {
+    process: Child,
+    pub stdin: tokio::process::ChildStdin,
+    pub stdout: tokio::process::ChildStdout,
+}
+
+impl SshLspProcess {
+    pub async fn wait(&mut self) -> Result<std::process::ExitStatus> {
+        self.process.wait().await.context("SSH LSP process wait failed")
+    }
+
+    pub fn kill(&mut self) -> Result<()> {
+        self.process.start_kill().context("Failed to kill SSH LSP process")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_connection_options() {
+        let options = SshConnectionOptions::new("example.com".to_string(), "user".to_string())
+            .with_port(2222);
+
+        assert_eq!(options.destination(), "user@example.com");
+        assert_eq!(options.connection_key(), "user@example.com:2222");
+    }
+
+    #[test]
+    fn test_ssh_host_parsing() {
+        let host: SshConnectionHost = "192.168.1.1".into();
+        match host {
+            SshConnectionHost::IpAddr(_) => {}
+            _ => panic!("Expected IP address"),
+        }
+
+        let host: SshConnectionHost = "example.com".into();
+        match host {
+            SshConnectionHost::Hostname(name) => assert_eq!(name, "example.com"),
+            _ => panic!("Expected hostname"),
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn ssh_check_master_returns_false_for_missing_socket() {
+        // Pointing at a socket that doesn't exist must surface as "not alive"
+        // rather than panicking or hanging.
+        let tmp = std::env::temp_dir().join(format!(
+            "lsp-proxy-ssh-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        assert!(!tmp.exists());
+        let alive = ssh_check_master(&tmp, "nobody@nowhere.invalid")
+            .await
+            .expect("ssh binary present");
+        assert!(!alive, "missing socket must not be reported as alive");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn wait_connected_reports_early_exit_fast() {
+        // Stand in for the ssh master with a program that exits immediately so
+        // we can exercise the early-exit branch without a real SSH target.
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg("echo 'boom' 1>&2; exit 7")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn test master");
+
+        let socket_path = std::env::temp_dir()
+            .join(format!("lsp-proxy-ssh-test-{}", uuid::Uuid::new_v4()));
+        let mut master = MasterProcess {
+            process: child,
+            socket_path,
+            destination: "nobody@nowhere.invalid".to_string(),
+        };
+
+        let start = std::time::Instant::now();
+        let err = master
+            .wait_connected()
+            .await
+            .expect_err("master exits non-zero, wait should fail");
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "early-exit detection took {:?}, expected well under MASTER_READY_TIMEOUT",
+            elapsed
+        );
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("exited early"), "unexpected message: {msg}");
+        assert!(
+            msg.contains("boom"),
+            "stderr ('boom') should be surfaced in the error, got: {msg}"
+        );
+    }
+}

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -109,6 +109,15 @@ impl SshConnectionOptions {
             None => self.destination(),
         }
     }
+
+    /// Returns the `-p <port>` argument pair when a non-default port is set,
+    /// or an empty vec otherwise. Use with `cmd.args(options.port_args())`.
+    pub fn port_args(&self) -> Vec<String> {
+        match self.port {
+            Some(port) => vec!["-p".to_string(), port.to_string()],
+            None => vec![],
+        }
+    }
 }
 
 /// SSH Socket封装
@@ -426,6 +435,7 @@ impl SshSocket {
             .arg("LogLevel=ERROR")
             .arg("-o")
             .arg("RemoteCommand=none")
+            .args(self.connection_options.port_args())
             .arg(self.connection_options.destination())
             .arg(command);
 
@@ -540,13 +550,17 @@ impl SshConnection {
 
         if master_guard.is_none() {
             let destination = self.socket.connection_options.destination();
-            let additional_args = self
+            let port_args = self.socket.connection_options.port_args();
+            let user_args = self
                 .socket
                 .connection_options
                 .args
                 .as_ref()
                 .cloned()
                 .unwrap_or_default();
+            // Prepend port args so they appear before any user-supplied args.
+            let mut additional_args = port_args;
+            additional_args.extend(user_args);
 
             #[cfg(not(target_os = "windows"))]
             let master =
@@ -594,6 +608,7 @@ impl SshConnection {
             .arg("LogLevel=ERROR")
             .arg("-o")
             .arg("RemoteCommand=none")
+            .args(self.socket.connection_options.port_args())
             .arg(self.socket.connection_options.destination())
             .arg(command);
 
@@ -624,6 +639,7 @@ impl SshConnection {
             .arg("LogLevel=ERROR")
             .arg("-o")
             .arg("RemoteCommand=none")
+            .args(self.socket.connection_options.port_args())
             .arg(local_path)
             .arg(format!(
                 "{}:{}",
@@ -705,6 +721,7 @@ impl SshConnection {
             .arg("ServerAliveInterval=15")
             .arg("-o")
             .arg("ServerAliveCountMax=3")
+            .args(self.socket.connection_options.port_args())
             .arg(self.socket.connection_options.destination())
             .arg(&command)
             .stdin(std::process::Stdio::piped())

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -1,15 +1,13 @@
 use anyhow::{anyhow, Context, Result};
-use log::{debug, error, info, warn};
+use log::{debug, info, warn};
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tempfile::TempDir;
-use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 
-use super::RemoteHost;
 
 /// Result of a remote command, preserving the exit code so callers can tell
 /// "binary not found" (non-zero exit) from "transport failure" (error on the
@@ -34,11 +32,11 @@ pub enum SshConnectionHost {
     Hostname(String),
 }
 
-impl SshConnectionHost {
-    pub fn to_string(&self) -> String {
+impl std::fmt::Display for SshConnectionHost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::IpAddr(ip) => ip.to_string(),
-            Self::Hostname(hostname) => hostname.clone(),
+            Self::IpAddr(ip) => write!(f, "{}", ip),
+            Self::Hostname(hostname) => write!(f, "{}", hostname),
         }
     }
 }
@@ -99,11 +97,12 @@ impl SshConnectionOptions {
     pub fn destination(&self) -> String {
         let host_str = self.host.to_string();
         match &self.username {
-            Some(username) => format!("{}@{}", username, host_str),
+            Some(username) => format!("{username}@{host_str}"),
             None => host_str,
         }
     }
 
+    #[allow(dead_code)]
     pub fn connection_key(&self) -> String {
         match self.port {
             Some(port) => format!("{}:{}", self.destination(), port),
@@ -117,6 +116,7 @@ struct SshSocket {
     connection_options: SshConnectionOptions,
     #[cfg(not(target_os = "windows"))]
     socket_path: PathBuf,
+    #[allow(dead_code)]
     envs: HashMap<String, String>,
 }
 
@@ -181,13 +181,13 @@ impl MasterProcess {
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
-            .args(&args)
+            .args(args)
             .args(&additional_args)
             .arg("-o")
             .arg(format!("ControlPath={}", socket_path.display()))
             .arg(destination);
 
-        debug!("Starting SSH master process: ssh {}", destination);
+        debug!("Starting SSH master process: ssh {destination}");
         let process = master_process
             .spawn()
             .context("Failed to spawn SSH master process")?;
@@ -279,9 +279,7 @@ impl MasterProcess {
                     format!("socket {} never appeared", self.socket_path.display())
                 };
                 return Err(anyhow!(
-                    "SSH master not ready within {:?} ({})",
-                    MASTER_READY_TIMEOUT,
-                    detail
+                    "SSH master not ready within {MASTER_READY_TIMEOUT:?} ({detail})"
                 ));
             }
 
@@ -377,7 +375,7 @@ impl SshSocket {
             // 16 hex chars of the UUID is 64 bits of entropy — more than
             // enough for per-session uniqueness.
             let short = format!("{:016x}", (uuid.as_u128() >> 64) as u64);
-            buf.push(format!("lspp-{}", short));
+            buf.push(format!("lspp-{short}"));
             buf
         };
 
@@ -408,12 +406,12 @@ impl SshSocket {
             .arg(self.connection_options.destination())
             .arg(command);
 
-        debug!("Executing SSH command: {}", command);
+        debug!("Executing SSH command: {command}");
         let output = cmd.output().await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow!("SSH command failed: {}", stderr));
+            return Err(anyhow!("SSH command failed: {stderr}"));
         }
 
         Ok(output.stdout)
@@ -506,7 +504,7 @@ impl SshConnection {
             .arg(self.socket.connection_options.destination())
             .arg(command);
 
-        debug!("Executing SSH command (with status): {}", command);
+        debug!("Executing SSH command (with status): {command}");
         let output = cmd.output().await.context("ssh command failed to launch")?;
         Ok(CommandOutput {
             exit_code: output.status.code(),
@@ -574,11 +572,10 @@ impl SshConnection {
             .copied()
             .unwrap_or(20);
         let mut command = format!(
-            "{} --remote-server --max-item {}",
-            remote_path, max_items
+            "{remote_path} --remote-server --max-item {max_items}"
         );
         if log_level > 0 {
-            command.push_str(&format!(" --log-level {}", log_level));
+            command.push_str(&format!(" --log-level {log_level}"));
         }
 
         let mut cmd = Command::new("ssh");
@@ -614,7 +611,7 @@ impl SshConnection {
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
 
-        info!("Starting remote LSP proxy: {}", command);
+        info!("Starting remote LSP proxy: {command}");
         let mut process = cmd.spawn().context("Failed to spawn remote LSP proxy")?;
 
         let stdin = process
@@ -634,13 +631,13 @@ impl SshConnection {
                 let mut lines = BufReader::new(stderr).lines();
                 loop {
                     match lines.next_line().await {
-                        Ok(Some(line)) => warn!("[remote stderr] {}", line),
+                        Ok(Some(line)) => warn!("[remote stderr] {line}"),
                         Ok(None) => {
                             debug!("[remote stderr] EOF");
                             break;
                         }
                         Err(e) => {
-                            warn!("[remote stderr] read error: {}", e);
+                            warn!("[remote stderr] read error: {e}");
                             break;
                         }
                     }
@@ -655,12 +652,14 @@ impl SshConnection {
         })
     }
 
+    #[allow(dead_code)]
     pub fn connection_key(&self) -> String {
         self.socket.connection_options.connection_key()
     }
 }
 
 /// SSH LSP进程包装
+#[allow(dead_code)]
 pub struct SshLspProcess {
     process: Child,
     pub stdin: tokio::process::ChildStdin,
@@ -668,6 +667,7 @@ pub struct SshLspProcess {
 }
 
 impl SshLspProcess {
+    #[allow(dead_code)]
     pub async fn wait(&mut self) -> Result<std::process::ExitStatus> {
         self.process
             .wait()
@@ -675,6 +675,7 @@ impl SshLspProcess {
             .context("SSH LSP process wait failed")
     }
 
+    #[allow(dead_code)]
     pub fn kill(&mut self) -> Result<()> {
         self.process
             .start_kill()

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -153,6 +153,16 @@ impl MasterProcess {
             "ControlPersist=yes",
             "-o",
             "ControlMaster=yes",
+            // Keepalive: send an SSH-level probe every 15s; if 3 go
+            // unanswered (~45s of silence) ssh tears the tunnel down
+            // instead of letting it sit half-dead until the OS TCP
+            // keepalive eventually notices (which can be hours on macOS).
+            // This is what turns a silently-broken link into a fast
+            // EOF that our `is_dead()` path can react to.
+            "-o",
+            "ServerAliveInterval=15",
+            "-o",
+            "ServerAliveCountMax=3",
             // Don't prompt for host-key confirmation when running
             // non-interactively; we treat the SSH config's trust of the host
             // as sufficient. Callers wanting stricter policy can override via
@@ -590,6 +600,14 @@ impl SshConnection {
             // override the binary we're trying to exec.
             .arg("-o")
             .arg("RemoteCommand=none")
+            // Same keepalive as the master — applies to this session's ssh
+            // channel (the one our Protobuf frames actually travel through).
+            // Without this, a silently-dead link would just hang RPC requests
+            // until our 30s per-request timeout fires, repeatedly.
+            .arg("-o")
+            .arg("ServerAliveInterval=15")
+            .arg("-o")
+            .arg("ServerAliveCountMax=3")
             .arg(self.socket.connection_options.destination())
             .arg(&command)
             .stdin(std::process::Stdio::piped())

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -8,7 +8,6 @@ use tempfile::TempDir;
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 
-
 /// Result of a remote command, preserving the exit code so callers can tell
 /// "binary not found" (non-zero exit) from "transport failure" (error on the
 /// Result).
@@ -164,6 +163,12 @@ impl Drop for MasterProcess {
 }
 
 impl MasterProcess {
+    /// Sentinel printed by the remote command to signal the SSH connection is
+    /// ready. Shared between `new()` (which embeds it in the remote command)
+    /// and `wait_connected()` (which scans stdout for it).
+    #[cfg(target_os = "windows")]
+    const CONNECTION_ESTABLISHED_MAGIC: &'static str = "LSP_PROXY_SSH_CONNECTION_ESTABLISHED";
+
     #[cfg(not(target_os = "windows"))]
     pub async fn new(
         socket_path: &std::path::Path,
@@ -233,12 +238,15 @@ impl MasterProcess {
 
     #[cfg(target_os = "windows")]
     pub async fn new(destination: &str, additional_args: Vec<String>) -> Result<Self> {
-        // Windows 不走 ControlMaster,仍保留一个 echo 标记后 sleep 的长连接占位。
+        // On Windows, `ControlMaster` and `ControlPath` are not supported:
+        // https://github.com/PowerShell/Win32-OpenSSH/issues/405
+        // https://github.com/PowerShell/Win32-OpenSSH/wiki/Project-Scope
+        //
+        // Using an ugly workaround to detect connection establishment
+        // -N doesn't work with JumpHosts as windows openssh never closes stdin in that case
         let args = [
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            "UserKnownHostsFile=NUL",
+            "-t",
+            &format!("echo '{}'; exec $0", Self::CONNECTION_ESTABLISHED_MAGIC),
         ];
 
         let mut master_process = Command::new("ssh");
@@ -247,10 +255,9 @@ impl MasterProcess {
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
-            .args(&args)
             .args(&additional_args)
             .arg(destination)
-            .arg("echo SSH_CONNECTION_ESTABLISHED; sleep 3600");
+            .args(&args);
 
         debug!("Starting SSH master process: ssh {}", destination);
         let process = master_process
@@ -323,37 +330,22 @@ impl MasterProcess {
     pub async fn wait_connected(&mut self) -> Result<()> {
         use tokio::io::{AsyncBufReadExt, BufReader};
 
-        let deadline = std::time::Instant::now() + MASTER_READY_TIMEOUT;
         let Some(stdout) = self.process.stdout.take() else {
             return Err(anyhow!("SSH master has no captured stdout to monitor"));
         };
-        let mut lines = BufReader::new(stdout).lines();
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
 
         loop {
-            if let Some(status) = self.process.try_wait()? {
-                return Err(anyhow!("SSH master exited early with status {}", status));
+            let n = reader.read_line(&mut line).await?;
+            if n == 0 {
+                return Err(anyhow!("SSH master stdout closed before readiness marker"));
             }
-
-            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-            if remaining.is_zero() {
-                return Err(anyhow!(
-                    "SSH master did not emit readiness marker within {:?}",
-                    MASTER_READY_TIMEOUT
-                ));
+            if line.contains(Self::CONNECTION_ESTABLISHED_MAGIC) {
+                info!("SSH master ready (saw readiness marker)");
+                return Ok(());
             }
-
-            match tokio::time::timeout(remaining, lines.next_line()).await {
-                Ok(Ok(Some(line))) if line.contains("SSH_CONNECTION_ESTABLISHED") => {
-                    info!("SSH master ready (saw readiness marker)");
-                    return Ok(());
-                }
-                Ok(Ok(Some(_))) => continue,
-                Ok(Ok(None)) => {
-                    return Err(anyhow!("SSH master stdout closed before readiness marker"));
-                }
-                Ok(Err(e)) => return Err(anyhow!("error reading SSH master stdout: {}", e)),
-                Err(_) => {} // tick around the outer loop so we can recheck try_wait
-            }
+            line.clear();
         }
     }
 

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -710,16 +710,18 @@ impl SshConnection {
             .get()
             .copied()
             .unwrap_or(20);
-
-        // `ssh host <cmd>` passes <cmd> to the remote login shell as a string
-        // argument to `sh -c`, so the remote path must be single-quote escaped
-        // to handle spaces and shell metacharacters safely.
-        let quoted_path = shell_single_quote(remote_path);
-        let mut inner = format!("{quoted_path} --remote-server --max-item {max_items}");
+        let mut inner = format!(
+            "{remote_path} --remote-server --max-item {max_items}"
+        );
         if log_level > 0 {
             inner.push_str(&format!(" --log-level {log_level}"));
         }
 
+        // Execute the remote binary directly.  The binary itself calls
+        // `load_login_shell_env()` at startup to capture and apply the login
+        // shell's environment (PATH, nvm, Homebrew, etc.), so we do not need
+        // any shell wrapper here.  Avoiding a wrapper removes all shell syntax
+        // compatibility issues (bash vs fish vs zsh) and stdout-pollution risk.
         let command = inner;
 
         let mut cmd = Command::new("ssh");
@@ -833,16 +835,6 @@ impl SshLspProcess {
     }
 }
 
-/// Wrap `s` in POSIX single quotes, escaping any embedded single quotes.
-///
-/// The result is safe to embed in a command string passed to a remote shell
-/// via `ssh host <cmd>`, where the shell interprets the string.
-/// Example: `/home/my user/bin` → `'/home/my user/bin'`
-/// Example: `it's here`        → `'it'"'"'s here'`
-fn shell_single_quote(s: &str) -> String {
-    format!("'{}'", s.replace('\'', "'\\''"))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -925,26 +917,5 @@ mod tests {
             msg.contains("boom"),
             "stderr ('boom') should be surfaced in the error, got: {msg}"
         );
-    }
-
-    #[test]
-    fn shell_single_quote_plain_path() {
-        assert_eq!(
-            shell_single_quote("/usr/local/bin/proxy"),
-            "'/usr/local/bin/proxy'"
-        );
-    }
-
-    #[test]
-    fn shell_single_quote_path_with_spaces() {
-        assert_eq!(
-            shell_single_quote("/home/my user/bin"),
-            "'/home/my user/bin'"
-        );
-    }
-
-    #[test]
-    fn shell_single_quote_embedded_single_quote() {
-        assert_eq!(shell_single_quote("it's here"), "'it'\\''s here'");
     }
 }

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -75,9 +75,12 @@ pub struct SshConnectionOptions {
 
 impl SshConnectionOptions {
     pub fn new(host: String, username: String) -> Self {
+        // Empty username means "let ssh resolve via ~/.ssh/config", which is
+        // the common case with SSH aliases like `Host home\n  User me`.
+        let username = if username.is_empty() { None } else { Some(username) };
         Self {
             host: host.into(),
-            username: Some(username),
+            username,
             port: None,
             args: None,
             connection_timeout: Some(30),

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -141,14 +141,24 @@ impl MasterProcess {
     ) -> Result<Self> {
         let args = [
             "-N",
+            // ControlPersist=yes keeps the master alive in the background
+            // after startup. With `ControlPersist=no` the master would exit
+            // as soon as its "initial client" (which with -N doesn't exist)
+            // would have closed — effectively making it exit immediately.
             "-o",
-            "ControlPersist=no",
+            "ControlPersist=yes",
             "-o",
             "ControlMaster=yes",
+            // Don't prompt for host-key confirmation when running
+            // non-interactively; we treat the SSH config's trust of the host
+            // as sufficient. Callers wanting stricter policy can override via
+            // connection args.
             "-o",
-            "StrictHostKeyChecking=no",
+            "StrictHostKeyChecking=accept-new",
+            // Also silence the "Permanently added … to known hosts" warning
+            // that litters stderr and made earlier debugging noisy.
             "-o",
-            "UserKnownHostsFile=/dev/null",
+            "LogLevel=ERROR",
         ];
 
         let mut master_process = Command::new("ssh");
@@ -215,15 +225,27 @@ impl MasterProcess {
     #[cfg(not(target_os = "windows"))]
     pub async fn wait_connected(&mut self) -> Result<()> {
         let deadline = std::time::Instant::now() + MASTER_READY_TIMEOUT;
+        // With ControlPersist=yes, ssh forks a background daemon and the
+        // foreground process exits 0 almost immediately. That's expected —
+        // the real master lives on via the control socket. Treat exit 0 as
+        // "daemonised successfully" and keep polling; only non-zero exits
+        // are actual failures.
+        let mut foreground_reaped = false;
 
         loop {
-            if let Some(status) = self.process.try_wait()? {
-                let stderr_msg = self.drain_stderr().await;
-                return Err(anyhow!(
-                    "SSH master exited early with status {}: {}",
-                    status,
-                    stderr_msg.trim()
-                ));
+            if !foreground_reaped {
+                if let Some(status) = self.process.try_wait()? {
+                    if status.success() {
+                        foreground_reaped = true;
+                    } else {
+                        let stderr_msg = self.drain_stderr().await;
+                        return Err(anyhow!(
+                            "SSH master exited early with status {}: {}",
+                            status,
+                            stderr_msg.trim()
+                        ));
+                    }
+                }
             }
 
             if self.socket_path.exists()
@@ -237,10 +259,18 @@ impl MasterProcess {
             }
 
             if std::time::Instant::now() >= deadline {
+                let detail = if foreground_reaped {
+                    format!(
+                        "ssh daemonised but socket {} never responded",
+                        self.socket_path.display()
+                    )
+                } else {
+                    format!("socket {} never appeared", self.socket_path.display())
+                };
                 return Err(anyhow!(
-                    "SSH master not ready within {:?} (socket {} never responded)",
+                    "SSH master not ready within {:?} ({})",
                     MASTER_READY_TIMEOUT,
-                    self.socket_path.display()
+                    detail
                 ));
             }
 
@@ -330,8 +360,20 @@ impl SshSocket {
     pub fn new(connection_options: SshConnectionOptions) -> Result<Self> {
         #[cfg(not(target_os = "windows"))]
         let socket_path = {
-            let temp_dir = std::env::temp_dir();
-            temp_dir.join(format!("lsp-proxy-ssh-{}", uuid::Uuid::new_v4()))
+            // sockaddr_un.sun_path is capped at 104 bytes on macOS / BSD.
+            // Combined with macOS's default $TMPDIR (`/var/folders/…/T/`,
+            // ~50 chars) and the ~17-char internal suffix OpenSSH appends
+            // during atomic rename, a full UUID was busting the limit:
+            //   /var/folders/d_/…/T/lsp-proxy-ssh-<uuid>.<xxxxxxxxx>  → >104
+            // Anchor at /tmp and truncate the random id so the total path
+            // stays comfortably short.
+            let mut buf = std::path::PathBuf::from("/tmp");
+            let uuid = uuid::Uuid::new_v4();
+            // 16 hex chars of the UUID is 64 bits of entropy — more than
+            // enough for per-session uniqueness.
+            let short = format!("{:016x}", (uuid.as_u128() >> 64) as u64);
+            buf.push(format!("lspp-{}", short));
+            buf
         };
 
         let envs = HashMap::new();
@@ -353,6 +395,11 @@ impl SshSocket {
 
         cmd.arg("-o")
             .arg("ControlMaster=no")
+            .arg("-T")
+            .arg("-o")
+            .arg("LogLevel=ERROR")
+            .arg("-o")
+            .arg("RemoteCommand=none")
             .arg(self.connection_options.destination())
             .arg(command);
 
@@ -442,6 +489,11 @@ impl SshConnection {
             .arg(format!("ControlPath={}", self.socket.socket_path.display()));
         cmd.arg("-o")
             .arg("ControlMaster=no")
+            .arg("-T")
+            .arg("-o")
+            .arg("LogLevel=ERROR")
+            .arg("-o")
+            .arg("RemoteCommand=none")
             .arg(self.socket.connection_options.destination())
             .arg(command);
 
@@ -470,6 +522,12 @@ impl SshConnection {
             .arg(format!("ControlPath={}", self.socket.socket_path.display()));
         cmd.arg("-o")
             .arg("ControlMaster=no")
+            // scp auto-infers no-TTY, but LogLevel + RemoteCommand overrides
+            // still help suppress spurious host config behaviour.
+            .arg("-o")
+            .arg("LogLevel=ERROR")
+            .arg("-o")
+            .arg("RemoteCommand=none")
             .arg(local_path)
             .arg(format!(
                 "{}:{}",
@@ -510,6 +568,17 @@ impl SshConnection {
 
         cmd.arg("-o")
             .arg("ControlMaster=no")
+            // -T disables pseudo-terminal allocation. If the user's SSH
+            // config has `RequestTTY yes` for this host, any PTY in the pipe
+            // would CR/LF-mangle the raw Protobuf frames we're about to send.
+            .arg("-T")
+            // Silence "Permanently added … known hosts" noise on stderr.
+            .arg("-o")
+            .arg("LogLevel=ERROR")
+            // Don't let a host-wide RemoteCommand (like `RemoteCommand /bin/zsh`)
+            // override the binary we're trying to exec.
+            .arg("-o")
+            .arg("RemoteCommand=none")
             .arg(self.socket.connection_options.destination())
             .arg(&command)
             .stdin(std::process::Stdio::piped())

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -556,11 +556,20 @@ impl SshConnection {
         // 把本地的 log-level 透传过去,远端才会写出有内容的 log
         // (默认落在远端 binary 所在目录下的 `remote-server.log`)。
         let log_level = crate::config::log_level();
-        let command = if log_level > 0 {
-            format!("{} --remote-server --log-level {}", remote_path, log_level)
-        } else {
-            format!("{} --remote-server", remote_path)
-        };
+        // Forward completion cap too. Remote defaults to 0 (the zero-valued
+        // `usize` from `Args::default()`); if it ever runs without this flag
+        // handle_completion slices every response to empty.
+        let max_items = crate::config::MAX_COMPLETION_ITEMS
+            .get()
+            .copied()
+            .unwrap_or(20);
+        let mut command = format!(
+            "{} --remote-server --max-item {}",
+            remote_path, max_items
+        );
+        if log_level > 0 {
+            command.push_str(&format!(" --log-level {}", log_level));
+        }
 
         let mut cmd = Command::new("ssh");
 

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -680,18 +680,18 @@ impl SshConnection {
             .get()
             .copied()
             .unwrap_or(20);
+
+        // `ssh host <cmd>` passes <cmd> to the remote login shell as a string
+        // argument to `sh -c`, so the remote path must be single-quote escaped
+        // to handle spaces and shell metacharacters safely.
+        let quoted_path = shell_single_quote(remote_path);
         let mut inner = format!(
-            "{remote_path} --remote-server --max-item {max_items}"
+            "{quoted_path} --remote-server --max-item {max_items}"
         );
         if log_level > 0 {
             inner.push_str(&format!(" --log-level {log_level}"));
         }
 
-        // Execute the remote binary directly.  The binary itself calls
-        // `load_login_shell_env()` at startup to capture and apply the login
-        // shell's environment (PATH, nvm, Homebrew, etc.), so we do not need
-        // any shell wrapper here.  Avoiding a wrapper removes all shell syntax
-        // compatibility issues (bash vs fish vs zsh) and stdout-pollution risk.
         let command = inner;
 
         let mut cmd = Command::new("ssh");
@@ -805,6 +805,16 @@ impl SshLspProcess {
     }
 }
 
+/// Wrap `s` in POSIX single quotes, escaping any embedded single quotes.
+///
+/// The result is safe to embed in a command string passed to a remote shell
+/// via `ssh host <cmd>`, where the shell interprets the string.
+/// Example: `/home/my user/bin` → `'/home/my user/bin'`
+/// Example: `it's here`        → `'it'"'"'s here'`
+fn shell_single_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -887,5 +897,20 @@ mod tests {
             msg.contains("boom"),
             "stderr ('boom') should be surfaced in the error, got: {msg}"
         );
+    }
+
+    #[test]
+    fn shell_single_quote_plain_path() {
+        assert_eq!(shell_single_quote("/usr/local/bin/proxy"), "'/usr/local/bin/proxy'");
+    }
+
+    #[test]
+    fn shell_single_quote_path_with_spaces() {
+        assert_eq!(shell_single_quote("/home/my user/bin"), "'/home/my user/bin'");
+    }
+
+    #[test]
+    fn shell_single_quote_embedded_single_quote() {
+        assert_eq!(shell_single_quote("it's here"), "'it'\\''s here'");
     }
 }

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -151,14 +151,33 @@ impl Drop for MasterProcess {
         // `emacs-lsp-proxy --remote-server` processes) receive SIGHUP and
         // exit when lsp-proxy restarts or a connection is evicted.
         //
+        // With ControlPersist=600 the foreground ssh daemonises immediately,
+        // so `self.process` is already dead by the time we reach here.
+        // We must use `ssh -O exit` to signal the background ControlMaster
+        // daemon; only then will muxed sessions receive a proper SSH
+        // disconnect.  Fall back to SIGKILL as a belt-and-suspenders measure.
+        //
         // `start_kill()` is synchronous (SIGKILL, no await needed) and safe
         // to call from any context, including outside the tokio runtime.
         // We intentionally avoid `tokio::spawn` here — Drop can be invoked
         // after the runtime has shut down, and spawn would panic in that case.
-        let _ = self.process.start_kill();
-
         #[cfg(not(target_os = "windows"))]
-        let _ = std::fs::remove_file(&self.socket_path);
+        {
+            let _ = std::process::Command::new("ssh")
+                .args([
+                    "-S",
+                    &self.socket_path.to_string_lossy(),
+                    "-O",
+                    "exit",
+                    "-o",
+                    "LogLevel=ERROR",
+                    &self.destination,
+                ])
+                .output();
+            let _ = std::fs::remove_file(&self.socket_path);
+        }
+
+        let _ = self.process.start_kill();
     }
 }
 
@@ -466,11 +485,15 @@ impl SshConnection {
                 {
                     let socket = mp.socket_path.to_string_lossy();
                     let ssh_args_base = [
-                        "-S", &socket,
-                        "-o", "ControlMaster=no",
+                        "-S",
+                        &socket,
+                        "-o",
+                        "ControlMaster=no",
                         "-T",
-                        "-o", "LogLevel=ERROR",
-                        "-o", "BatchMode=yes",
+                        "-o",
+                        "LogLevel=ERROR",
+                        "-o",
+                        "BatchMode=yes",
                         &mp.destination,
                     ];
 
@@ -488,14 +511,28 @@ impl SshConnection {
                         .arg("pkill -TERM -f 'emacs-lsp-proxy.*--remote-server'; true")
                         .output();
                     match kill_result {
-                        Ok(_) => info!("sent SIGTERM to remote emacs-lsp-proxy on {}", mp.destination),
-                        Err(e) => warn!("could not send SIGTERM to remote on {}: {e}", mp.destination),
+                        Ok(_) => info!(
+                            "sent SIGTERM to remote emacs-lsp-proxy on {}",
+                            mp.destination
+                        ),
+                        Err(e) => warn!(
+                            "could not send SIGTERM to remote on {}: {e}",
+                            mp.destination
+                        ),
                     }
 
                     // Step 2: Gracefully close the ControlMaster so it sends
                     // proper SSH disconnect messages.
                     let exit_result = std::process::Command::new("ssh")
-                        .args(["-S", &socket, "-O", "exit", "-o", "LogLevel=ERROR", &mp.destination])
+                        .args([
+                            "-S",
+                            &socket,
+                            "-O",
+                            "exit",
+                            "-o",
+                            "LogLevel=ERROR",
+                            &mp.destination,
+                        ])
                         .output();
                     match exit_result {
                         Ok(out) if out.status.success() => {
@@ -503,7 +540,8 @@ impl SshConnection {
                         }
                         Ok(out) => warn!(
                             "ssh -O exit failed for {} (exit={:?}): {}",
-                            mp.destination, out.status.code(),
+                            mp.destination,
+                            out.status.code(),
                             String::from_utf8_lossy(&out.stderr).trim()
                         ),
                         Err(e) => warn!("ssh -O exit could not run for {}: {e}", mp.destination),
@@ -677,9 +715,7 @@ impl SshConnection {
         // argument to `sh -c`, so the remote path must be single-quote escaped
         // to handle spaces and shell metacharacters safely.
         let quoted_path = shell_single_quote(remote_path);
-        let mut inner = format!(
-            "{quoted_path} --remote-server --max-item {max_items}"
-        );
+        let mut inner = format!("{quoted_path} --remote-server --max-item {max_items}");
         if log_level > 0 {
             inner.push_str(&format!(" --log-level {log_level}"));
         }
@@ -893,12 +929,18 @@ mod tests {
 
     #[test]
     fn shell_single_quote_plain_path() {
-        assert_eq!(shell_single_quote("/usr/local/bin/proxy"), "'/usr/local/bin/proxy'");
+        assert_eq!(
+            shell_single_quote("/usr/local/bin/proxy"),
+            "'/usr/local/bin/proxy'"
+        );
     }
 
     #[test]
     fn shell_single_quote_path_with_spaces() {
-        assert_eq!(shell_single_quote("/home/my user/bin"), "'/home/my user/bin'");
+        assert_eq!(
+            shell_single_quote("/home/my user/bin"),
+            "'/home/my user/bin'"
+        );
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,6 +15,17 @@ pub fn current_working_dir() -> PathBuf {
         .expect("Cound't determine current working directory")
 }
 
+/// Truncate `s` to at most `max_bytes` bytes, respecting UTF-8 character boundaries.
+pub fn truncate_preview(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    match s.char_indices().map(|(i, _)| i).take_while(|&i| i <= max_bytes).last() {
+        Some(i) if i < s.len() => &s[..i],
+        _ => &s[..max_bytes],
+    }
+}
+
 pub mod path {
     use crate::utils::current_working_dir;
     use etcetera::home_dir;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -331,7 +331,7 @@ fn are_diagnostic_equal(d1: &Diagnostic, d2: &Diagnostic) -> bool {
         && d1.source == d2.source
 }
 
-pub fn is_diagnostic_vectors_equal(vec1: &Vec<&Diagnostic>, vec2: &Vec<Diagnostic>) -> bool {
+pub fn is_diagnostic_vectors_equal(vec1: &[&Diagnostic], vec2: &[Diagnostic]) -> bool {
     if vec1.len() != vec2.len() {
         return false;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSH-backed remote-server mode with remote LSP proxy, remote status, deploy/upload, and interactive Emacs deploy command.

* **Improvements**
  * TRAMP-aware URI handling, robust remote routing with heartbeat/liveness, safer I/O/connection lifecycle, workspace-edit “propose as diff” flow, and expanded completion/logging diagnostics.

* **Configuration**
  * New CLI/runtime flags and runtime options for remote mode and logging; language-server entries refined.

* **Documentation**
  * Added Remote Development guide, deployment steps, and troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jadestrong/lsp-proxy/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->