### PR TITLE
Add Support for Remote Language Servers via Docker/TRAMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,21 @@ roots = ["go.mod", "go.work"]
 language-servers = ["gopls"]
 ```
 
+### Remote Language Servers (Docker / TRAMP)
+
+Configure a language server with a `[language-server.*.connection]` table where `type = "docker-exec"` and `container` is set to the Docker container name or ID. The server binary path is resolved inside the container. Optional `workdir` maps to `docker exec -w`.
+
+```toml
+[language-server.ts-ls]
+command = "typescript-language-server"
+args = ["--stdio"]
+
+[language-server.ts-ls.connection]
+type = "docker-exec"
+container = "my-devcontainer"
+# workdir = "/workspaces/proj"
+```
+
 ### Built-in Language Servers
 
 LSP-Proxy includes default configurations for:

--- a/lsp-proxy-core.el
+++ b/lsp-proxy-core.el
@@ -477,6 +477,7 @@ Records BEG, END and PRE-CHANGE-LENGTH locally."
         (progn
           (unless (file-exists-p buffer-file-name)
             (save-buffer))
+          (ignore-errors (lsp-proxy--register-remote-root buffer-file-name))
           (let* ((is-large-file (and (boundp 'lsp-proxy--is-large-file) lsp-proxy--is-large-file))
                  (initial-content (if is-large-file
                                       (lsp-proxy--get-initial-content)

--- a/lsp-proxy-large-file.el
+++ b/lsp-proxy-large-file.el
@@ -83,7 +83,7 @@
       (setq lsp-proxy--loading-timeout-timer nil))
     (remhash buffer-file-name lsp-proxy--loading-files)
     (lsp-proxy--notify 'emacs/largeFileLoadCancel
-                       (list :uri (concat "file://" buffer-file-name)))
+                       (list :uri (concat "file://" (file-local-name buffer-file-name))))
     (lsp-proxy--warn "Large file loading cancelled")))
 
 ;;; Timeout handling
@@ -118,7 +118,7 @@
                (lsp-proxy--large-file-p file-path))
 
       (message "[LSP-PROXY-CHUNK] 🚀 Starting large file loading: %s" (file-name-nondirectory file-path))
-      
+
       (puthash file-path buffer lsp-proxy--loading-files)
       (with-current-buffer buffer
         (setq lsp-proxy--large-file-loading-state 'pending
@@ -130,7 +130,7 @@
       (lsp-proxy--setup-loading-timeout buffer)
 
       (lsp-proxy--notify 'emacs/largeFileLoadStart
-                         (list :uri (concat "file://" file-path)
+                         (list :uri (concat "file://" (file-local-name file-path))
                                :totalSize (nth 7 (file-attributes file-path))
                                :chunkSize lsp-proxy-large-file-chunk-size))
 
@@ -171,7 +171,7 @@
               lsp-proxy--large-file-loading-progress progress))
 
       (lsp-proxy--notify 'emacs/largeFileChunk
-                         (list :uri (concat "file://" file-path)
+                         (list :uri (concat "file://" (file-local-name file-path))
                                :chunkIndex chunk-index
                                :chunkData chunk-data
                                :startPos start-pos
@@ -189,7 +189,7 @@
 (defun lsp-proxy--complete-large-file-loading (buffer file-path)
   "Complete large file loading process."
   (message "[LSP-PROXY-CHUNK] 🎉 Completing large file loading for: %s" (file-name-nondirectory file-path))
-  
+
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
       (setq lsp-proxy--large-file-loading-state 'completed

--- a/lsp-proxy-large-file.el
+++ b/lsp-proxy-large-file.el
@@ -83,7 +83,7 @@
       (setq lsp-proxy--loading-timeout-timer nil))
     (remhash buffer-file-name lsp-proxy--loading-files)
     (lsp-proxy--notify 'emacs/largeFileLoadCancel
-                       (list :uri (concat "file://" (file-local-name buffer-file-name))))
+                       (list :uri (url-encode-url (concat "file://" (file-local-name buffer-file-name)))))
     (lsp-proxy--warn "Large file loading cancelled")))
 
 ;;; Timeout handling
@@ -130,7 +130,7 @@
       (lsp-proxy--setup-loading-timeout buffer)
 
       (lsp-proxy--notify 'emacs/largeFileLoadStart
-                         (list :uri (concat "file://" (file-local-name file-path))
+                         (list :uri (url-encode-url (concat "file://" (file-local-name file-path)))
                                :totalSize (nth 7 (file-attributes file-path))
                                :chunkSize lsp-proxy-large-file-chunk-size))
 
@@ -171,7 +171,7 @@
               lsp-proxy--large-file-loading-progress progress))
 
       (lsp-proxy--notify 'emacs/largeFileChunk
-                         (list :uri (concat "file://" (file-local-name file-path))
+                         (list :uri (url-encode-url (concat "file://" (file-local-name file-path)))
                                :chunkIndex chunk-index
                                :chunkData chunk-data
                                :startPos start-pos

--- a/lsp-proxy-utils.el
+++ b/lsp-proxy-utils.el
@@ -138,6 +138,38 @@ FORMAT and ARGS is the same as for `message'."
 (defvar-local lsp-proxy--current-project-root nil
   "Cached project root for current buffer.")
 
+(defvar lsp-proxy--remote-root-prefixes
+  (make-hash-table :test 'equal)
+  "Stripped workspace root string -> TRAMP prefix (e.g. `/docker:host:`).")
+
+(defun lsp-proxy--register-remote-root (buffer-file)
+  "If BUFFER-FILE is remote, map its stripped project root to the TRAMP prefix."
+  (when (and buffer-file (file-remote-p buffer-file))
+    (let ((prefix (file-remote-p buffer-file))
+          (local-root (file-local-name
+                       (directory-file-name (lsp-proxy-project-root)))))
+      (when (and prefix local-root (cl-plusp (length local-root)))
+        (unless (gethash local-root lsp-proxy--remote-root-prefixes)
+          (puthash local-root prefix lsp-proxy--remote-root-prefixes))))))
+
+(defun lsp-proxy--lookup-remote-prefix (path)
+  "Return the TRAMP prefix registered for the longest stripped root matching PATH."
+  (when (and path (cl-plusp (length path)))
+    (let ((best-len 0)
+          (best-prefix nil))
+      (maphash
+       (lambda (root prefix)
+         (when (and (cl-plusp (length root))
+                    (<= (length root) (length path))
+                    (string-prefix-p root path)
+                    (or (= (length root) (length path))
+                        (eq (aref path (length root)) ?/)))
+           (when (> (length root) best-len)
+             (setq best-len (length root)
+                   best-prefix prefix))))
+       lsp-proxy--remote-root-prefixes)
+      best-prefix)))
+
 (defun lsp-proxy-project-root ()
   "Return the project root of current project."
   (if lsp-proxy--current-project-root
@@ -187,13 +219,18 @@ If the system is not Windows, return the original path."
 (defun lsp-proxy--uri-to-path (uri)
   "Convert URI to file path."
   (when (keywordp uri) (setq uri (substring (symbol-name uri) 1)))
-  (let* ((remote-prefix (and lsp-proxy--current-project-root (file-remote-p lsp-proxy--current-project-root)))
-         (url (url-generic-parse-url uri)))
+  (let* ((url (url-generic-parse-url uri))
+         (decoded (and (string= "file" (url-type url))
+                       (url-unhex-string (url-filename url))))
+         (remote-prefix
+          (or (and lsp-proxy--current-project-root
+                   (file-remote-p lsp-proxy--current-project-root))
+              (and decoded (lsp-proxy--lookup-remote-prefix decoded)))))
     ;; Only parse file:// URIs, leave other URI untouched as
     ;; `file-name-handler-alist' should know how to handle them
     ;; (bug#58790).
     (if (string= "file" (url-type url))
-        (let* ((retval (url-unhex-string (url-filename url)))
+        (let* ((retval decoded)
                ;; Remove the leading "/" for local MS Windows-style paths.
                (normalized (if (and (not remote-prefix)
                                     (eq system-type 'windows-nt)

--- a/lsp-proxy-utils.el
+++ b/lsp-proxy-utils.el
@@ -223,9 +223,9 @@ If the system is not Windows, return the original path."
          (decoded (and (string= "file" (url-type url))
                        (url-unhex-string (url-filename url))))
          (remote-prefix
-          (or (and lsp-proxy--current-project-root
-                   (file-remote-p lsp-proxy--current-project-root))
-              (and decoded (lsp-proxy--lookup-remote-prefix decoded)))))
+          (or (and decoded (lsp-proxy--lookup-remote-prefix decoded))
+              (and lsp-proxy--current-project-root
+                   (file-remote-p lsp-proxy--current-project-root)))))
     ;; Only parse file:// URIs, leave other URI untouched as
     ;; `file-name-handler-alist' should know how to handle them
     ;; (bug#58790).

--- a/src/client.rs
+++ b/src/client.rs
@@ -33,7 +33,7 @@ use crate::{
     msg::RequestId,
     registry,
     syntax::{self, Connection, LanguageServerFeature, LanguageServerFeatures, SupportWorkspace},
-    utils::{defer, find_lsp_workspace, get_activate_time},
+    utils::{defer, find_lsp_workspace, get_activate_time, resolve_root_path},
 };
 
 fn workspace_for_uri(uri: lsp::Url) -> lsp::WorkspaceFolder {
@@ -183,10 +183,11 @@ impl Client {
         let support_workspace = features
             .map(|f| &f.support_workspace)
             .unwrap_or(&default_workspace);
-        let root_path = find_lsp_workspace(
+        let root_path = resolve_root_path(
+            connection,
             doc_path.map(|p| p.as_path()),
             root_markers,
-            support_workspace
+            support_workspace,
         );
         let root_uri = lsp::Url::from_file_path(&root_path).ok();
 
@@ -267,6 +268,7 @@ impl Client {
             req_timeout,
             features: features.cloned(),
             activate_time: Arc::new(Mutex::new(get_activate_time())),
+            pid_visible_to_server: matches!(connection, syntax::Connection::Stdio),
         };
 
         Ok((client, server_rx, initialize_notify))

--- a/src/client.rs
+++ b/src/client.rs
@@ -168,6 +168,25 @@ impl Client {
             .unwrap();
     }
 
+    fn validate_config_files(
+        features: Option<&LanguageServerFeatures>,
+        root_path: &std::path::Path,
+    ) -> registry::Result<()> {
+        if let Some(features) = features {
+            if !features.config_files.is_empty()
+                && !features
+                    .config_files
+                    .iter()
+                    .any(|cf| root_path.join(cf).exists())
+            {
+                return Err(registry::Error::Other(anyhow::anyhow!(
+                    "No config file found for language server"
+                )));
+            }
+        }
+        Ok(())
+    }
+
     pub fn start(
         cmd: &str,
         args: &[String],
@@ -203,52 +222,32 @@ impl Client {
             root_path
         );
 
+        Self::validate_config_files(features, &root_path)?;
+
         let mut command = match connection {
             syntax::Connection::Stdio => {
                 let resolved = which::which(cmd).map_err(|err| anyhow::anyhow!(err))?;
-                if let Some(features) = features {
-                    if !features.config_files.is_empty()
-                        && !features
-                            .config_files
-                            .iter()
-                            .any(|cf| root_path.join(cf).exists())
-                    {
-                        return Err(registry::Error::Other(anyhow::anyhow!(
-                            "No config file found for language server"
-                        )));
-                    }
-                }
                 let mut c = Command::new(resolved);
-                c.args(args).current_dir(&root_path);
+                c.args(args)
+                    .current_dir(&root_path)
+                    .envs(server_envirment);
                 c
             }
             syntax::Connection::DockerExec { container, workdir } => {
                 let docker = which::which("docker").map_err(|err| anyhow::anyhow!(err))?;
-                if let Some(features) = features {
-                    if !features.config_files.is_empty()
-                        && !features
-                            .config_files
-                            .iter()
-                            .any(|cf| root_path.join(cf).exists())
-                    {
-                        return Err(registry::Error::Other(anyhow::anyhow!(
-                            "No config file found for language server"
-                        )));
-                    }
-                }
                 let mut c = Command::new(docker);
                 c.arg("exec").arg("-i");
                 for (key, value) in &server_envirment {
                     c.arg("-e").arg(format!("{key}={value}"));
                 }
-                let cwd = workdir.as_deref().unwrap_or(root_path.as_path());
-                c.arg("-w").arg(cwd);
+                if let Some(wd) = workdir.as_deref() {
+                    c.arg("-w").arg(wd);
+                }
                 c.arg(container).arg(cmd).args(args);
                 c
             }
         };
         command
-            .envs(server_envirment)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/src/client.rs
+++ b/src/client.rs
@@ -224,8 +224,23 @@ impl Client {
             }
             syntax::Connection::DockerExec { container, workdir } => {
                 let docker = which::which("docker").map_err(|err| anyhow::anyhow!(err))?;
+                if let Some(features) = features {
+                    if !features.config_files.is_empty()
+                        && !features
+                            .config_files
+                            .iter()
+                            .any(|cf| root_path.join(cf).exists())
+                    {
+                        return Err(registry::Error::Other(anyhow::anyhow!(
+                            "No config file found for language server"
+                        )));
+                    }
+                }
                 let mut c = Command::new(docker);
                 c.arg("exec").arg("-i");
+                for (key, value) in &server_envirment {
+                    c.arg("-e").arg(format!("{key}={value}"));
+                }
                 let cwd = workdir.as_deref().unwrap_or(root_path.as_path());
                 c.arg("-w").arg(cwd);
                 c.arg(container).arg(cmd).args(args);

--- a/src/client.rs
+++ b/src/client.rs
@@ -74,6 +74,10 @@ pub struct Client {
     req_timeout: u64,
     features: Option<LanguageServerFeatures>,
     pub(crate) activate_time: Arc<Mutex<u128>>,
+    /// Whether the proxy's pid is meaningful to the server. False for
+    /// transports that cross a PID namespace (e.g. docker exec): the server
+    /// would poll a host PID it cannot see, decide its parent died, and exit.
+    pid_visible_to_server: bool,
 }
 
 #[allow(dead_code)]
@@ -628,7 +632,11 @@ impl Client {
 
         #[allow(deprecated)]
         let params = lsp::InitializeParams {
-            process_id: Some(std::process::id()),
+            process_id: if self.pid_visible_to_server {
+                Some(std::process::id())
+            } else {
+                None
+            },
             root_path: self.root_path.to_str().map(|path| path.to_owned()),
             root_uri: self.root_uri.clone(),
             initialization_options: Some(self.config.clone().unwrap_or(json!({}))),

--- a/src/client.rs
+++ b/src/client.rs
@@ -32,7 +32,7 @@ use crate::{
     },
     msg::RequestId,
     registry,
-    syntax::{LanguageServerFeature, LanguageServerFeatures, SupportWorkspace},
+    syntax::{self, Connection, LanguageServerFeature, LanguageServerFeatures, SupportWorkspace},
     utils::{defer, find_lsp_workspace, get_activate_time},
 };
 
@@ -176,6 +176,7 @@ impl Client {
         req_timeout: u64,
         doc_path: Option<&std::path::PathBuf>,
         features: Option<&LanguageServerFeatures>,
+        connection: &Connection,
     ) -> registry::Result<(Self, UnboundedReceiver<(usize, Call)>, Arc<Notify>)> {
         // find the closest root directory as the LSP workspace
         let default_workspace = SupportWorkspace::default();
@@ -197,20 +198,44 @@ impl Client {
             root_path
         );
 
-        // Resolve path to the binary
-        let cmd = which::which(cmd).map_err(|err| anyhow::anyhow!(err))?;
-
-        let process = Command::new(cmd)
+        let mut command = match connection {
+            syntax::Connection::Stdio => {
+                let resolved = which::which(cmd).map_err(|err| anyhow::anyhow!(err))?;
+                if let Some(features) = features {
+                    if !features.config_files.is_empty()
+                        && !features
+                            .config_files
+                            .iter()
+                            .any(|cf| root_path.join(cf).exists())
+                    {
+                        return Err(registry::Error::Other(anyhow::anyhow!(
+                            "No config file found for language server"
+                        )));
+                    }
+                }
+                let mut c = Command::new(resolved);
+                c.args(args).current_dir(&root_path);
+                c
+            }
+            syntax::Connection::DockerExec { container, workdir } => {
+                let docker = which::which("docker").map_err(|err| anyhow::anyhow!(err))?;
+                let mut c = Command::new(docker);
+                c.arg("exec").arg("-i");
+                let cwd = workdir.as_deref().unwrap_or(root_path.as_path());
+                c.arg("-w").arg(cwd);
+                c.arg(container).arg(cmd).args(args);
+                c
+            }
+        };
+        command
             .envs(server_envirment)
-            .args(args)
-            .current_dir(&root_path)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             // make sure the process is reaped on drop
-            .kill_on_drop(true)
-            .spawn();
-        let mut process = process?;
+            .kill_on_drop(true);
+
+        let mut process = command.spawn()?;
 
         // TODO: do we need bufreader/writer here? or do we use async wrappers on unblock?
         let writer = BufWriter::new(process.stdin.take().expect("Failed to open stdin"));
@@ -219,20 +244,6 @@ impl Client {
 
         let (server_rx, server_tx, initialize_notify) =
             Transport::start(reader, writer, stderr, id, name.clone());
-
-        if let Some(features) = features {
-            if !features.config_files.is_empty()
-                && !features.config_files.iter().any(|config_file| {
-                    // "Check if the root + config file exists."
-                    let config_file_path = root_path.clone().join(config_file);
-                    config_file_path.exists()
-                })
-            {
-                return Err(registry::Error::Other(anyhow::anyhow!(
-                    "No config file found for language server"
-                )));
-            }
-        }
 
         let workspace_folders = root_uri
             .clone()

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -214,7 +214,8 @@ impl Registry {
         let id = self.counter;
         self.counter += 1;
 
-        let NewClient(client, incoming) = start_client(id, name, ls_config, config, doc_path, features)?;
+        let NewClient(client, incoming) =
+            start_client(id, name, ls_config, config, doc_path, features)?;
         self.incoming.push(UnboundedReceiverStream::new(incoming));
         Ok(client)
     }
@@ -234,11 +235,15 @@ impl Registry {
             .iter()
             .filter_map(|features @ LanguageServerFeatures { name, .. }| {
                 if self.inner.contains_key(name) {
-                    let client =
-                        match self.start_client(name.clone(), language_config, doc_path.as_ref(), Some(features)) {
-                            Ok(client) => client,
-                            error => return Some(error),
-                        };
+                    let client = match self.start_client(
+                        name.clone(),
+                        language_config,
+                        doc_path.as_ref(),
+                        Some(features),
+                    ) {
+                        Ok(client) => client,
+                        error => return Some(error),
+                    };
 
                     self.inner
                         .entry(name.to_string())
@@ -303,6 +308,7 @@ fn start_client(
         ls_config.timeout,
         doc_path,
         ls_features,
+        &ls_config.connection,
     )?;
 
     let client = Arc::new(client);

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -6,8 +6,8 @@ use crate::{
     },
     lsp_ext,
     msg::RequestId,
-    syntax::{self, LanguageConfiguration, LanguageServerConfiguration, LanguageServerFeatures},
-    utils::{path, find_lsp_workspace},
+    syntax::{self, Connection, LanguageConfiguration, LanguageServerConfiguration, LanguageServerFeatures},
+    utils::{path, resolve_root_path},
 };
 use anyhow::anyhow;
 use futures_util::stream::SelectAll;
@@ -122,10 +122,18 @@ impl Registry {
                 } = feature;
                 if let Some(clients) = self.inner.get(name) {
                     // find the root path of the current file based on the support_workspace strategy
-                    let file_root = find_lsp_workspace(
+                    let default_connection = Connection::default();
+                    let connection = self
+                        .syn_loader
+                        .language_server_configs()
+                        .get(name)
+                        .map(|cfg| &cfg.connection)
+                        .unwrap_or(&default_connection);
+                    let file_root = resolve_root_path(
+                        connection,
                         doc_path.map(|p| p.as_path()),
                         &language_config.roots,
-                        support_workspace
+                        support_workspace,
                     );
                     
                     // try to find existing clients based on support_workspace

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -291,6 +291,18 @@ where
     serializer.end()
 }
 
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum Connection {
+    #[default]
+    Stdio,
+    DockerExec {
+        container: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        workdir: Option<std::path::PathBuf>,
+    },
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct LanguageServerConfiguration {
@@ -306,6 +318,8 @@ pub struct LanguageServerConfiguration {
     pub timeout: u64,
     #[serde(default, skip_serializing, deserialize_with = "deserialize_lsp_config")]
     pub experimental: Option<serde_json::Value>,
+    #[serde(default)]
+    pub connection: Connection,
 }
 
 fn default_timeout() -> u64 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -242,6 +242,34 @@ pub fn find_lsp_workspace(
     lsp_workspace.unwrap_or(current_working_dir())
 }
 
+pub fn resolve_root_path(
+    connection: &crate::syntax::Connection,
+    doc_path: Option<&Path>,
+    root_markers: &[String],
+    support_workspace: &crate::syntax::SupportWorkspace,
+) -> PathBuf {
+    match connection {
+        crate::syntax::Connection::Stdio => {
+            find_lsp_workspace(doc_path, root_markers, support_workspace)
+        }
+        crate::syntax::Connection::DockerExec { workdir, .. } => {
+            if let Some(w) = workdir {
+                return w.clone();
+            }
+            let root = doc_path
+                .and_then(|p| p.parent())
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| PathBuf::from("/"));
+            log::warn!(
+                "DockerExec: no `workdir` configured; falling back to document parent as LSP root: {:?} (doc_path={:?}). Set `workdir` in the language-server config to silence this.",
+                root,
+                doc_path
+            );
+            root
+        }
+    }
+}
+
 /// Find the closest root directory for a file.
 /// This function searches upward from the file path to find the most specific
 /// directory that contains any of the workspace root markers, but doesn't go beyond the git workspace.


### PR DESCRIPTION
`lsp-proxy` fails to spawn servers when opening a file in a container via TRAMP.

### Summary

This PR adds support for running language servers in docker containers. It introduces a `Connection` enum with a docker-exec connection type for spawning servers inside containers. 

### Changes
- Added support for spawning language servers inside Docker containers via docker exec
- Added `Connection` enum 
- Added `connection` field to `LanguageServerConfiguration`
- Added support for  stripping TRAMP prefixes and mapping them to URIs in `lsp-proxy--uri-to-path`
- Added `pid_visible_to_server` to `null` out PID for remote servers (`typescript-language-server` crashes if it can't see the PID)
- Updated README

### Status

It seems to be working but I have only tested 3 servers. I plan to do more testing on more servers soon. I can test something specific if requested. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable connection types for language servers, including Docker-exec and TRAMP remote support.
  * Language server startup now respects configured workdir for remote connections.

* **Bug Fixes**
  * Improved remote file path and URI handling for TRAMP/Docker workflows.
  * Better handling of unsaved buffers to ensure root registration proceeds.
  * Fixed construction of large-file notification URIs for remote files.

* **Documentation**
  * Added README guide for configuring remote language servers (Docker / TRAMP).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jadestrong/lsp-proxy/pull/56)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->