### PR TITLE
fix(bytecode): escape non-ASCII LSP content strings for Emacs read

### DIFF
--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -45,15 +45,21 @@ impl LispObject {
                 result.reserve(s.len() * 2 + 2);
                 result.push('"');
                 for c in s.chars() {
-                    if c == '\"' || c == '\\' {
-                        result.push('\\');
-                        result.push(c);
-                    } else if (c as u32) < 32 || (c as u32) == 127 {
-                        // not printable
-                        // NOTE: cannot use escape for c in 128..=255, otherwise the string would become unibyte
-                        result += &format!("\\{:03o}", c as u32);
-                    } else {
-                        result.push(c);
+                    match c {
+                        '"' | '\\' => {
+                            result.push('\\');
+                            result.push(c);
+                        }
+                        '\0'..='\x1f' | '\x7f' => result.push_str(&format!("\\{:03o}", c as u32)),
+                        '\x20'..='\x7e' => result.push(c),
+                        _ => {
+                            let codepoint = c as u32;
+                            if codepoint <= 0xffff {
+                                result.push_str(&format!("\\u{codepoint:04X}"));
+                            } else {
+                                result.push_str(&format!("\\U{codepoint:08X}"));
+                            }
+                        }
                     }
                 }
                 result.push('"');


### PR DESCRIPTION
LSP message content is UTF-8 by protocol, but bytecode payloads are read by Emacs from binary jsonrpc buffers. Emitting raw non-ASCII UTF-8 bytes there makes `read` produce unibyte strings, which Emacs 32 rejects when they are later passed to `json-serialize`.

Emit Unicode escapes for non-ASCII characters in bytecode string constants so Emacs reads them back as multibyte strings, fixing resolve requests such as `completionItem/resolve`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved REPL string display with enhanced character escaping, now properly showing quotes, backslashes, control characters as octal sequences, and Unicode characters as escape sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->