### PR TITLE
feat: Make yasnippet an optional dependency

### DIFF
--- a/lsp-proxy-completion.el
+++ b/lsp-proxy-completion.el
@@ -263,9 +263,10 @@ Apply text edits in CANDIDATE when STATUS is finished or exact."
          (textEdit (plist-get item :textEdit))
          (additionalTextEdits (plist-get item :additionalTextEdits))
          (startPoint (- marker (length candidate)))
-         (insertTextMode (plist-get item :insertTextMode))
          (start (plist-get proxy-item :start))
-         (end (plist-get proxy-item :end)))
+         (end (plist-get proxy-item :end))
+         (snippet-fn (and (eq insertTextFormat 2)
+                          (eglot--snippet-expansion-fn))))
     (cond (textEdit
            (let* ((range (plist-get textEdit :range))
                   (replaceStart (eglot--lsp-position-to-point (plist-get range :start)))
@@ -274,19 +275,18 @@ Apply text edits in CANDIDATE when STATUS is finished or exact."
                   (insertText (s-replace "\r" "" (or newText ""))))
              (delete-region start end)
              (delete-region replaceStart replaceEnd)
-             (insert insertText)))
+             (goto-char replaceStart)
+             (funcall (or snippet-fn #'insert) insertText)))
           ;; A snippet should be inserted, but using plain
           ;; `insertText'.  This requires us to delete the
           ;; whole completion, since `insertText' is the full
           ;; completion's text.
+          (snippet-fn
+           (delete-region (- end (length candidate)) end)
+           (funcall snippet-fn (or insertText label)))
           (insertText
            (delete-region (- end (length candidate)) end)
            (insert (or insertText label))))
-    (lsp-proxy--indent-lines startPoint (point) insertTextMode)
-    (when (eq insertTextFormat 2)
-      (lsp-proxy--expand-snippet (buffer-substring startPoint (point))
-                                 startPoint
-                                 (point)))
     (if (cl-plusp (length additionalTextEdits))
         (eglot--apply-text-edits additionalTextEdits)
       (if-let* ((resolved-item (get-text-property 0 'resolved-item candidate)))

--- a/lsp-proxy-core.el
+++ b/lsp-proxy-core.el
@@ -329,7 +329,8 @@ Only sends requests if servers are available."
                                                                 "--max-item" (number-to-string lsp-proxy-max-completion-item)
                                                                 "--max-diagnostics-push" (number-to-string lsp-proxy-diagnostics-max-push-count)
                                                                 "--copilot-server-name" lsp-proxy-copilot-server-name)
-                                                          (when lsp-proxy-enable-bytecode '("--bytecode")))
+                                                          (when lsp-proxy-enable-bytecode '("--bytecode"))
+                                                          (when (eglot--snippet-expansion-fn) '("--enable-snippets")))
                                          :connection-type 'pipe
                                          :stderr (get-buffer-create "*lsp proxy stderr*")
                                          :noquery t)))))

--- a/lsp-proxy-utils.el
+++ b/lsp-proxy-utils.el
@@ -17,7 +17,6 @@
 (require 'url-util)
 (require 'project)
 (require 'eglot)
-(require 'yasnippet nil t)
 
 (defvar lsp-proxy-mode)
 (defvar lsp-proxy-enable-org-babel)
@@ -264,54 +263,6 @@ fails to open on the remote FS)."
               normalized
             (concat remote-prefix normalized)))
       uri)))
-
-;;; Snippet expansion
-
-(declare-function yas-expand-snippet "ext:yasnippet")
-
-(defun lsp-proxy--expand-snippet (snippet &optional start end expand-env)
-  "Wrapper of `yas-expand-snippet' with all of it arguments.
-The snippet will be convert to LSP style and indent according to
-LSP server result."
-  (require 'yasnippet)
-  (let* ((inhibit-field-text-motion t)
-         (yas-wrap-around-region nil)
-         (yas-indent-line 'none)
-         (yas-also-auto-indent-first-line nil))
-    (yas-expand-snippet snippet start end expand-env)))
-
-;;; Text indentation utilities
-(defun lsp-proxy--indent-lines (start end &optional insert-text-mode?)
-  "Indent from START to END based on INSERT-TEXT-MODE? value.
-- When INSERT-TEXT-MODE? is provided
-  - if it's `lsp/insert-text-mode-as-it', do no editor indentation.
-  - if it's `lsp/insert-text-mode-adjust-indentation', adjust leading
-    whitespaces to match the line where text is inserted.
-- When it's not provided, using `indent-line-function' for each line."
-  (save-excursion
-    (goto-char end)
-    (let* ((end-line (line-number-at-pos))
-           (offset (save-excursion
-                     (goto-char start)
-                     (current-indentation)))
-           (indent-line-function
-            (cond ((equal insert-text-mode? 1)
-                   #'ignore)
-                  ((or (equal insert-text-mode? 2)
-                       ;; Indenting snippets is extremely slow in `org-mode' buffers
-                       ;; since it has to calculate indentation based on SRC block
-                       ;; position.  Thus we use relative indentation as default.
-                       (derived-mode-p 'org-mode))
-                   (lambda () (save-excursion
-                                (beginning-of-line)
-                                (indent-to-column offset))))
-                  (t indent-line-function))))
-      (goto-char start)
-      (forward-line)
-      (while (and (not (eobp))
-                  (<= (line-number-at-pos) end-line))
-        (funcall indent-line-function)
-        (forward-line)))))
 
 ;;; Request parameters
 

--- a/lsp-proxy.el
+++ b/lsp-proxy.el
@@ -9,7 +9,7 @@
 ;; Version: 0.4.0
 ;; Keywords: abbrev bib c calendar comm convenience data docs emulations extensions faces files frames games hardware help hypermedia i18n internal languages lisp local maint mail matching mouse multimedia news outlines processes terminals tex tools unix vc wp
 ;; Homepage: https://github.com/jadestrong/lsp-proxy
-;; Package-Requires: ((emacs "30.1") (s "1.13.1") (eldoc "1.14.0") (ht "2.4") (dash "2.19.1") (f "0.21.0") (yasnippet "0.14.1"))
+;; Package-Requires: ((emacs "30.1") (s "1.13.1") (eldoc "1.14.0") (ht "2.4") (dash "2.19.1") (f "0.21.0"))
 
 ;; This file is not part of GNU Emacs.
 
@@ -37,7 +37,6 @@
 (require 'f)
 (require 'ht)
 (require 'dash)
-(require 'yasnippet)
 
 ;; Load lsp-proxy modules
 (require 'lsp-proxy-utils)

--- a/src/args.rs
+++ b/src/args.rs
@@ -13,6 +13,7 @@ pub struct Args {
     pub max_item_num: usize,
     pub max_diagnostics_push: usize,
     pub enable_bytecode: bool,
+    pub enable_snippets: bool,
     pub copilot_server_name: String,
 }
 
@@ -57,6 +58,7 @@ impl Args {
                 "--stdio" => args.stdio = true,
                 "--remote-server" => args.remote_server = true,
                 "--bytecode" => args.enable_bytecode = true,
+                "--enable-snippets" => args.enable_snippets = true,
                 "-h" | "--help" => {
                     args.show_help = true;
                     return Ok(args);
@@ -99,6 +101,7 @@ impl Args {
         println!("        --remote-server       Run as a remote server (reads/writes Protobuf Envelopes on stdio)");
         println!("        LSP_PROXY_REMOTE_BINARY_PATH  env var: remote host path for the deployed binary");
         println!("        --bytecode            Enable bytecode optimization for JSON-RPC");
+        println!("        --enable-snippets     Advertise snippet completion support to language servers");
         println!("    -h, --help               Print help information");
         println!("    -V, --version            Print version information");
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ pub static MAX_COMPLETION_ITEMS: once_cell::sync::OnceCell<usize> =
 pub static MAX_DIAGNOSTICS_PUSH: once_cell::sync::OnceCell<usize> =
     once_cell::sync::OnceCell::new();
 pub static ENABLE_BYTECODE: once_cell::sync::OnceCell<bool> = once_cell::sync::OnceCell::new();
+pub static ENABLE_SNIPPETS: once_cell::sync::OnceCell<bool> = once_cell::sync::OnceCell::new();
 
 pub static COPILOT_SERVER_NAME: once_cell::sync::OnceCell<String> =
     once_cell::sync::OnceCell::new();
@@ -35,6 +36,10 @@ pub fn set_max_diagnostics_push(max_diagnostics: usize) {
 
 pub fn set_enable_bytecode(enable: bool) {
     ENABLE_BYTECODE.set(enable).ok();
+}
+
+pub fn set_enable_snippets(enable: bool) {
+    ENABLE_SNIPPETS.set(enable).ok();
 }
 
 pub fn set_copilot_server_name(name: String) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ use anyhow::{Context, Result};
 use args::Args;
 use config::{
     initialize_config_file, initialize_log_file, set_enable_bytecode, set_max_completion_items,
-    set_max_diagnostics_push,
+    set_enable_snippets, set_max_diagnostics_push,
 };
 use log::{error, info};
 use logging::init_tracing;
@@ -91,6 +91,7 @@ fn try_main() -> Result<()> {
     set_max_completion_items(args.max_item_num);
     set_max_diagnostics_push(args.max_diagnostics_push);
     set_enable_bytecode(args.enable_bytecode);
+    set_enable_snippets(args.enable_snippets);
     set_copilot_server_name(args.copilot_server_name);
     initialize_remote_binary_path();
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -313,8 +313,12 @@ fn start_client(
         let value = _client
             .capabilities
             .get_or_try_init(|| {
+                let enable_snippets = crate::config::ENABLE_SNIPPETS
+                    .get()
+                    .copied()
+                    .unwrap_or(false);
                 _client
-                    .initialize(true)
+                    .initialize(enable_snippets)
                     .map_ok(|response| response.capabilities)
             })
             .await;

--- a/src/remote/ssh.rs
+++ b/src/remote/ssh.rs
@@ -666,9 +666,14 @@ impl SshConnection {
             .get()
             .copied()
             .unwrap_or(20);
-        let mut inner = format!(
-            "{remote_path} --remote-server --max-item {max_items}"
-        );
+        let mut inner = format!("{remote_path} --remote-server --max-item {max_items}");
+        if crate::config::ENABLE_SNIPPETS
+            .get()
+            .copied()
+            .unwrap_or(false)
+        {
+            inner.push_str(" --enable-snippets");
+        }
         if log_level > 0 {
             inner.push_str(&format!(" --log-level {log_level}"));
         }


### PR DESCRIPTION
Only advertise snippet support to language servers when yasnippet is available. Add `--enable-snippets` flag to the backend, passed from Emacs only when a snippet expansion function is detected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new `--enable-snippets` command-line flag to configure snippet completion support
  * Enhanced snippet handling in completion items with improved text replacement logic

* **Chores**
  * Removed yasnippet dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->