### PR TITLE
fix(nix): Add missing test dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,9 @@
           cargoLock.lockFile = ./Cargo.lock;
           RUSTFLAGS = "-C target-cpu=native";
           buildType = "release";
-	  
+          nativeBuildInputs = with pkgs; [
+            openssh
+          ];
           meta = with pkgs.lib; {
             description = "An LSP client for Emacs implemented in Rust";
             homepage = "https://github.com/jadestrong/lsp-proxy";


### PR DESCRIPTION
## Summary

Fix the Nix build by adding `openssh` to `nativeBuildInputs`.

The build requires SSH tooling during the Nix build/test process, but it was not available in the isolated Nix environment. This change makes the dependency explicit so the flake builds successfully.

## Verification

- Confirmed that the Nix build failure is resolved with this dependency added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to include OpenSSH support during packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->